### PR TITLE
feat(profiles): prominent paid-tuning entry — 「✦ 想更像这个角色？申请专业优化」

### DIFF
--- a/launcher/pages/profiles_page.py
+++ b/launcher/pages/profiles_page.py
@@ -31,7 +31,6 @@ from launcher.theme import (
     mono_font,
     sans_font,
     title_font,
-    tracked,
 )
 from launcher.ui import GhostButton, PrimaryButton
 
@@ -322,10 +321,28 @@ class ProfilesMixin:
                     padx=12, pady=6).pack(side="left", padx=(0, 6))
         GhostButton(actions, "导入档案…", command=self._ui_import,
                     padx=12, pady=6).pack(side="left", padx=6)
-        GhostButton(actions, "导出当前档案…", command=self._ui_export_active,
+        GhostButton(actions, "导出当前档案（可分享）…", command=self._ui_export_active,
                     padx=12, pady=6).pack(side="left", padx=6)
-        GhostButton(actions, "打包咨询包…", command=self.open_consult_wizard,
-                    padx=12, pady=6).pack(side="left", padx=6)
+
+        # Funnel entry: guide toward the paid tuning service for this voice.
+        # Opens the consult wizard (samples + profile + env in one zip).
+        promo = tk.Frame(host, bg=TM_BG)
+        promo.pack(fill="x", pady=(8, 2))
+        PrimaryButton(
+            promo,
+            "✦ 想更像这个角色？申请专业优化",
+            command=self.open_consult_wizard,
+            padx=14,
+            pady=8,
+        ).pack(side="left")
+        tk.Label(
+            promo,
+            text="软件免费；我们代调一套最贴合你嗓音+这个角色的配置",
+            font=sans_font(9),
+            bg=TM_BG,
+            fg=TM_META,
+            anchor="w",
+        ).pack(side="left", padx=(10, 0))
 
     def _profile_row(self, parent, *, pid, name, source, score, active) -> None:
         edge = TM_ACCENT if active else TM_HAIRLINE


### PR DESCRIPTION
The models-page profile panel now leads with a primary button 「✦ 想更像这个角色？申请专业优化」 plus the tagline 软件免费；我们代调一套
最贴合你嗓音+这个角色的配置. It opens the existing consult wizard (launcher/pages/consult_page.py), which already gathers samples + profile
+ env/perf + model identity in one zip — so there is exactly one intake path and it is impossible to miss.

Reworked after the consult-pack feature landed on tm-release: the earlier standalone bundle tool (tools/optimize_request.py + its tests) duplicated launcher/consult_pack and is dropped; the subdued 打包咨询包… ghost button is replaced by the primary entry. Also removes now-unused imports.

pyflakes clean; suite 162 passed + composition test green on 3.12.


Claude-Session: https://claude.ai/code/session_01PEqwiZZoAirwiXCRpoMHMd

# Pull request checklist

- [ ] The PR has a proper title. Use [Semantic Commit Messages](https://seesparkbox.com/foundry/semantic_commit_messages). (No more branch-name title please)
- [ ] Make sure this is ready to be merged into the relevant branch. Please don't create a PR and let it hang for a few days.
- [ ] Ensure you can run the codes you submitted succesfully. These submissions will be prioritized for review:

    Introduce improvements in program execution speed;

    Introduce improvements in synthesis quality;

    Fix existing bugs reported by user feedback (or you met);

    Introduce more convenient user operations.

# PR type

- Bug fix / new feature / synthesis quality improvement / program execution speed improvement

# Description

- Describe what this pull request is for.
- What will it affect.

# Screenshot

- Please include a screenshot if applicable
