### PR TITLE
feat(app): stage 4 voice catalog & community store

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -59,6 +59,15 @@ cd /d path\to\repo\app
 npm run tauri:dev
 ```
 
+## Voice catalog & community store (stage 4)
+
+- `voices_list` / `voices_select` — local `User_Data/models` + legacy weights
+- Index panel: bind / use / unbind `.index` (copied next to `.pth`)
+- Profiles: list / switch / save / import / export `.tmvp`
+- Import `.pth` / `.index` / `.zip`; delete / rename / promote legacy
+- Community store dialog: dual-source catalog, series zone, third-party disclaimer,
+  multi-connection download via shared `download.rs` (`DownloadKind::VoicePack`)
+
 ## Runtime provision (stage 3)
 
 - `provision_status` — Runtime ready? GPU recommend (WMI, no torch).

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -98,6 +98,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
+name = "ashpd"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
+dependencies = [
+ "async-fs",
+ "async-net",
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.5",
+ "raw-window-handle",
+ "serde",
+ "serde_repr",
+ "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "zbus",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,6 +167,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +204,17 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
 ]
 
 [[package]]
@@ -542,7 +595,7 @@ checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -870,6 +923,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,6 +1009,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "dlopen2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,6 +1054,12 @@ dependencies = [
  "selectors",
  "tendril",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
@@ -1490,7 +1569,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi 6.0.0",
- "rand_core",
+ "rand_core 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -1720,6 +1799,12 @@ dependencies = [
  "http-body",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
 
 [[package]]
 name = "httparse"
@@ -2860,6 +2945,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
 name = "portable-atomic"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2888,6 +2979,15 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "precomputed-hash"
@@ -2996,7 +3096,7 @@ dependencies = [
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
- "rand",
+ "rand 0.10.2",
  "rand_pcg",
  "ring",
  "rustc-hash",
@@ -3046,13 +3146,42 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3067,7 +3196,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3226,6 +3355,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+dependencies = [
+ "ashpd",
+ "block2",
+ "dispatch2",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "pollster",
+ "raw-window-handle",
+ "urlencoding",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3372,7 +3525,9 @@ version = "1.3.0"
 dependencies = [
  "flate2",
  "hex",
+ "regex",
  "reqwest 0.12.28",
+ "rfd",
  "ripget",
  "serde",
  "serde_json",
@@ -3382,6 +3537,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-opener",
  "tokio",
+ "zip",
 ]
 
 [[package]]
@@ -3458,6 +3614,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -4015,6 +4177,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "jni 0.21.1",
  "libc",
  "log",
@@ -4747,6 +4910,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "urlpattern"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4914,6 +5083,66 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016ccf01d1c58b6f8999612813e17c9b2390f7d70671428869913310f83f54b8"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
+dependencies = [
+ "bitflags 2.13.1",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "pkg-config",
 ]
 
 [[package]]
@@ -5612,6 +5841,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "zerofrom"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5672,10 +5921,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "thiserror 2.0.19",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zvariant"
@@ -5686,6 +5964,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
+ "url",
  "winnow 1.0.4",
  "zvariant_derive",
  "zvariant_utils",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -26,3 +26,6 @@ sha2 = "0.10"
 hex = "0.4"
 tar = "0.4"
 flate2 = "1"
+zip = { version = "2", default-features = false, features = ["deflate"] }
+rfd = "0.15"
+regex = "1"

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 //! RVC Fabric shell (Tauri).
 //!
-//! Stages 1–3: window/UI, worker bridge, Runtime provision (download/extract).
+//! Stages 1–4: window/UI, worker bridge, Runtime provision, voice catalog & store.
 
 mod catalog;
 mod download;
@@ -8,6 +8,8 @@ mod extract;
 mod paths;
 mod protocol;
 mod provision;
+mod store;
+mod voices;
 mod worker;
 
 use std::path::PathBuf;
@@ -200,6 +202,222 @@ fn provision_cancel() -> Result<(), String> {
     Ok(())
 }
 
+// ----- Stage 4: voices + store ------------------------------------------------
+
+#[tauri::command]
+fn voices_list(state: State<'_, Mutex<AppState>>) -> Result<Value, String> {
+    let root = root_clone(&state)?;
+    Ok(voices::list_voices(&root))
+}
+
+#[tauri::command]
+fn voices_select(
+    state: State<'_, Mutex<AppState>>,
+    path: Option<String>,
+    dir: Option<String>,
+    name: Option<String>,
+) -> Result<Value, String> {
+    let root = root_clone(&state)?;
+    voices::select_voice(
+        &root,
+        path.as_deref().unwrap_or(""),
+        dir.as_deref().unwrap_or(""),
+        name.as_deref().unwrap_or(""),
+    )
+}
+
+#[tauri::command]
+fn voices_current(state: State<'_, Mutex<AppState>>) -> Result<Value, String> {
+    let root = root_clone(&state)?;
+    Ok(voices::current_selection_summary(&root))
+}
+
+#[tauri::command]
+fn voices_index_list(
+    state: State<'_, Mutex<AppState>>,
+    model_dir: String,
+) -> Result<Value, String> {
+    let root = root_clone(&state)?;
+    voices::list_index_bindings(&root, &model_dir)
+}
+
+#[tauri::command]
+fn voices_index_use(
+    state: State<'_, Mutex<AppState>>,
+    model_dir: String,
+    index_path: String,
+) -> Result<Value, String> {
+    let root = root_clone(&state)?;
+    voices::set_active_index(&root, &model_dir, &index_path)
+}
+
+#[tauri::command]
+fn voices_index_bind(
+    state: State<'_, Mutex<AppState>>,
+    model_dir: String,
+    index_src: Option<String>,
+) -> Result<Value, String> {
+    let root = root_clone(&state)?;
+    let src = match index_src.filter(|s| !s.is_empty()) {
+        Some(s) => s,
+        None => voices::pick_index_file().ok_or_else(|| "已取消".to_string())?,
+    };
+    voices::bind_index_file(&root, &model_dir, &src)
+}
+
+#[tauri::command]
+fn voices_index_unbind(
+    state: State<'_, Mutex<AppState>>,
+    model_dir: String,
+    index_path: String,
+) -> Result<Value, String> {
+    let root = root_clone(&state)?;
+    voices::unbind_index(&root, &model_dir, &index_path)
+}
+
+#[tauri::command]
+fn voices_profiles_list(
+    state: State<'_, Mutex<AppState>>,
+    model_dir: String,
+) -> Result<Value, String> {
+    let root = root_clone(&state)?;
+    voices::list_profiles(&root, &model_dir)
+}
+
+#[tauri::command]
+fn voices_profile_use(
+    state: State<'_, Mutex<AppState>>,
+    model_dir: String,
+    profile_id: String,
+) -> Result<Value, String> {
+    let root = root_clone(&state)?;
+    voices::set_active_profile(&root, &model_dir, &profile_id)
+}
+
+#[tauri::command]
+fn voices_profile_save(
+    state: State<'_, Mutex<AppState>>,
+    model_dir: String,
+    name: String,
+) -> Result<Value, String> {
+    let root = root_clone(&state)?;
+    voices::save_current_as_profile(&root, &model_dir, &name)
+}
+
+#[tauri::command]
+fn voices_profile_delete(
+    state: State<'_, Mutex<AppState>>,
+    model_dir: String,
+    profile_id: String,
+) -> Result<Value, String> {
+    let root = root_clone(&state)?;
+    voices::delete_profile(&root, &model_dir, &profile_id)
+}
+
+#[tauri::command]
+fn voices_profile_import(
+    state: State<'_, Mutex<AppState>>,
+    model_dir: String,
+) -> Result<Value, String> {
+    let root = root_clone(&state)?;
+    voices::import_profile(&root, &model_dir)
+}
+
+#[tauri::command]
+fn voices_profile_export(
+    state: State<'_, Mutex<AppState>>,
+    model_dir: String,
+) -> Result<Value, String> {
+    let root = root_clone(&state)?;
+    voices::export_active_profile(&root, &model_dir)
+}
+
+#[tauri::command]
+fn voices_import(
+    state: State<'_, Mutex<AppState>>,
+    paths: Option<Vec<String>>,
+    current_model_dir: Option<String>,
+) -> Result<Value, String> {
+    let root = root_clone(&state)?;
+    let files = match paths.filter(|p| !p.is_empty()) {
+        Some(p) => p,
+        None => {
+            let picked = voices::pick_import_files();
+            if picked.is_empty() {
+                return Err("已取消".into());
+            }
+            picked
+        }
+    };
+    voices::import_files(
+        &root,
+        &files,
+        current_model_dir.as_deref(),
+    )
+}
+
+#[tauri::command]
+fn voices_delete(
+    state: State<'_, Mutex<AppState>>,
+    model_dir: String,
+) -> Result<Value, String> {
+    let root = root_clone(&state)?;
+    voices::delete_voice(&root, &model_dir)
+}
+
+#[tauri::command]
+fn voices_rename(
+    state: State<'_, Mutex<AppState>>,
+    model_dir: String,
+    new_name: String,
+) -> Result<Value, String> {
+    let root = root_clone(&state)?;
+    voices::rename_voice(&root, &model_dir, &new_name)
+}
+
+#[tauri::command]
+fn voices_promote(
+    state: State<'_, Mutex<AppState>>,
+    pth_path: String,
+) -> Result<Value, String> {
+    let root = root_clone(&state)?;
+    voices::promote_legacy(&root, &pth_path)
+}
+
+#[tauri::command]
+fn voices_open_dir(state: State<'_, Mutex<AppState>>) -> Result<(), String> {
+    let root = root_clone(&state)?;
+    voices::open_models_dir(&root)
+}
+
+#[tauri::command]
+fn store_catalog(
+    state: State<'_, Mutex<AppState>>,
+    prefer_remote: Option<bool>,
+) -> Result<Value, String> {
+    let root = root_clone(&state)?;
+    Ok(store::fetch_store_catalog(
+        &root,
+        prefer_remote.unwrap_or(true),
+    ))
+}
+
+#[tauri::command]
+fn store_install(
+    app: AppHandle,
+    state: State<'_, Mutex<AppState>>,
+    entry: Value,
+) -> Result<Value, String> {
+    let root = root_clone(&state)?;
+    store::install_voice_entry(app, root, entry)
+}
+
+#[tauri::command]
+fn store_cancel() -> Result<(), String> {
+    store::cancel_store_download();
+    Ok(())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let root = paths::product_root();
@@ -226,6 +444,27 @@ pub fn run() {
             provision_status,
             provision_start,
             provision_cancel,
+            voices_list,
+            voices_select,
+            voices_current,
+            voices_index_list,
+            voices_index_use,
+            voices_index_bind,
+            voices_index_unbind,
+            voices_profiles_list,
+            voices_profile_use,
+            voices_profile_save,
+            voices_profile_delete,
+            voices_profile_import,
+            voices_profile_export,
+            voices_import,
+            voices_delete,
+            voices_rename,
+            voices_promote,
+            voices_open_dir,
+            store_catalog,
+            store_install,
+            store_cancel,
         ])
         .setup(move |_app| {
             let root_bg = root.clone();

--- a/app/src-tauri/src/paths.rs
+++ b/app/src-tauri/src/paths.rs
@@ -135,3 +135,40 @@ pub fn worker_script(root: &Path) -> PathBuf {
 pub fn package_meta_path(root: &Path) -> PathBuf {
     root.join("package_meta.json")
 }
+
+pub fn models_dir(root: &Path) -> PathBuf {
+    user_data(root).join("models")
+}
+
+pub fn engine_weights(root: &Path) -> PathBuf {
+    root.join("assets").join("weights")
+}
+
+pub fn ch_banner_dir(root: &Path) -> PathBuf {
+    user_data(root).join("ch-banner")
+}
+
+pub fn app_config_path(root: &Path) -> PathBuf {
+    user_data(root).join("app_config.json")
+}
+
+pub fn update_cache(root: &Path) -> PathBuf {
+    user_data(root).join("update_cache")
+}
+
+pub fn ensure_user_dirs(root: &Path) -> std::io::Result<()> {
+    fs_create_all(&user_data(root))?;
+    fs_create_all(&models_dir(root))?;
+    fs_create_all(&ch_banner_dir(root))?;
+    fs_create_all(&update_cache(root))?;
+    fs_create_all(&control_dir(root))?;
+    fs_create_all(&logs_dir(root))?;
+    Ok(())
+}
+
+fn fs_create_all(p: &Path) -> std::io::Result<()> {
+    if !p.is_dir() {
+        std::fs::create_dir_all(p)?;
+    }
+    Ok(())
+}

--- a/app/src-tauri/src/store.rs
+++ b/app/src-tauri/src/store.rs
@@ -1,0 +1,817 @@
+//! Community voice store: catalog fetch + zip/files install.
+//! Mirrors launcher/online/catalog.py + voice_install.py (subset for stage 4).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use serde_json::{json, Map, Value};
+use tauri::{AppHandle, Emitter};
+
+use crate::download::{self, DownloadKind, DownloadRequest};
+use crate::paths;
+use crate::voices::safe_model_dir_name;
+
+const CNB_RAW_MAIN: &str = "https://cnb.cool/Turing-Mirror/RVC-Fabric-Releases/-/git/raw/main";
+const MIN_PTH_BYTES: u64 = 50_000;
+
+static STORE_CANCEL: AtomicBool = AtomicBool::new(false);
+
+fn bundled_catalog_path(root: &Path) -> PathBuf {
+    root.join("configs").join("online_catalog.json")
+}
+
+fn cache_catalog_path(root: &Path) -> PathBuf {
+    paths::user_data(root).join("catalog_cache.json")
+}
+
+fn parse_voice_entry(d: &Value, force_official: Option<bool>) -> Option<Value> {
+    if !d.is_object() {
+        return None;
+    }
+    let id = d
+        .get("id")
+        .or_else(|| d.get("name"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    if id.is_empty() {
+        return None;
+    }
+    let mut cover = d
+        .get("cover_url")
+        .or_else(|| d.get("cover"))
+        .or_else(|| d.get("banner"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    if !cover.is_empty()
+        && !cover.to_ascii_lowercase().starts_with("http://")
+        && !cover.to_ascii_lowercase().starts_with("https://")
+    {
+        cover = format!(
+            "{CNB_RAW_MAIN}/{}",
+            cover.replace('\\', "/").trim_start_matches('/')
+        );
+    }
+    let pack_url = d
+        .get("pack_url")
+        .or_else(|| d.get("zip_url"))
+        .or_else(|| d.get("pack"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let pth_url = d
+        .get("pth_url")
+        .or_else(|| d.get("pth"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    if pack_url.is_empty() && pth_url.is_empty() {
+        return None;
+    }
+    let mut official = true;
+    if let Some(f) = force_official {
+        official = f;
+    } else if let Some(v) = d.get("official").or_else(|| d.get("fabric_official")) {
+        if let Some(b) = v.as_bool() {
+            official = b;
+        } else if let Some(s) = v.as_str() {
+            official = !matches!(s.to_ascii_lowercase().as_str(), "0" | "false" | "no" | "n" | "");
+        }
+    }
+    let author = d
+        .get("author")
+        .or_else(|| d.get("creator"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let size = d
+        .get("size_bytes")
+        .or_else(|| d.get("size"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    Some(json!({
+        "id": id,
+        "name": d.get("name").and_then(|v| v.as_str()).unwrap_or(&id),
+        "tag": d.get("tag").and_then(|v| v.as_str()).unwrap_or("音色"),
+        "version": d.get("version").and_then(|v| v.as_str()).unwrap_or("1"),
+        "package_type": d.get("package_type").or_else(|| d.get("type")).and_then(|v| v.as_str()).unwrap_or(""),
+        "pack_url": pack_url,
+        "pth_url": pth_url,
+        "index_url": d.get("index_url").and_then(|v| v.as_str()).unwrap_or(""),
+        "cover_url": cover,
+        "size_bytes": size,
+        "sha256": d.get("sha256").and_then(|v| v.as_str()).unwrap_or(""),
+        "description": d.get("description").or_else(|| d.get("desc")).and_then(|v| v.as_str()).unwrap_or(""),
+        "author": author,
+        "author_url": d.get("author_url").or_else(|| d.get("author_link")).and_then(|v| v.as_str()).unwrap_or(""),
+        "date": d.get("date").or_else(|| d.get("released")).and_then(|v| v.as_str()).unwrap_or(""),
+        "series": d.get("series").or_else(|| d.get("series_name")).or_else(|| d.get("collection")).and_then(|v| v.as_str()).unwrap_or(""),
+        "origin": d.get("origin").and_then(|v| v.as_str()).unwrap_or(""),
+        "source_url": d.get("source_url").or_else(|| d.get("repo_url")).and_then(|v| v.as_str()).unwrap_or(""),
+        "official": official,
+    }))
+}
+
+fn parse_voice_list(raw: &Value, force_official: Option<bool>) -> Vec<Value> {
+    let Some(arr) = raw.as_array() else {
+        return Vec::new();
+    };
+    arr.iter()
+        .filter_map(|item| parse_voice_entry(item, force_official))
+        .collect()
+}
+
+fn catalog_from_data(data: &Value, source: &str) -> Value {
+    let voices = parse_voice_list(
+        data.get("voices")
+            .or_else(|| data.get("models"))
+            .unwrap_or(&json!([])),
+        None,
+    );
+    let thirdparty = parse_voice_list(
+        data.get("thirdparty_voices")
+            .or_else(|| data.get("third_party_voices"))
+            .unwrap_or(&json!([])),
+        Some(false),
+    );
+    json!({
+        "source": source,
+        "voices": voices,
+        "thirdparty_voices": thirdparty,
+        "fetch_error": "",
+    })
+}
+
+fn is_voice_installed(root: &Path, voice_id: &str) -> bool {
+    let Ok(name) = safe_model_dir_name(voice_id) else {
+        return false;
+    };
+    let dir = paths::models_dir(root).join(name);
+    if !dir.is_dir() {
+        return false;
+    }
+    // has any .pth
+    if let Ok(rd) = fs::read_dir(&dir) {
+        for e in rd.flatten() {
+            if e.path()
+                .extension()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+                .eq_ignore_ascii_case("pth")
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Fetch / merge online catalog; annotate installed flags.
+pub fn fetch_store_catalog(root: &Path, prefer_remote: bool) -> Value {
+    let _ = paths::ensure_user_dirs(root);
+    let mut data = json!({});
+    let mut source = "empty";
+    let mut fetch_error = String::new();
+
+    // bundled
+    let bundled = bundled_catalog_path(root);
+    if bundled.is_file() {
+        if let Ok(s) = fs::read_to_string(&bundled) {
+            if let Ok(v) = serde_json::from_str::<Value>(&s) {
+                data = v;
+                source = "bundled";
+            }
+        }
+    }
+    // cache
+    let cache_p = cache_catalog_path(root);
+    if cache_p.is_file() {
+        if let Ok(s) = fs::read_to_string(&cache_p) {
+            if let Ok(v) = serde_json::from_str::<Value>(&s) {
+                if source == "empty" {
+                    data = v;
+                    source = "cache";
+                }
+            }
+        }
+    }
+
+    if prefer_remote {
+        match crate::catalog::fetch_remote_catalog(25) {
+            Ok(remote) => {
+                data = remote;
+                source = "remote";
+                if let Ok(text) = serde_json::to_string_pretty(&data) {
+                    let _ = fs::write(&cache_p, text);
+                }
+            }
+            Err(e) => {
+                fetch_error = e;
+                if source == "empty" {
+                    source = "error";
+                }
+            }
+        }
+    }
+
+    let mut cat = catalog_from_data(&data, source);
+    if let Some(obj) = cat.as_object_mut() {
+        obj.insert("fetch_error".into(), json!(fetch_error));
+    }
+
+    // annotate installed
+    for key in ["voices", "thirdparty_voices"] {
+        if let Some(arr) = cat.get_mut(key).and_then(|v| v.as_array_mut()) {
+            for v in arr.iter_mut() {
+                if let Some(obj) = v.as_object_mut() {
+                    let id = obj
+                        .get("id")
+                        .and_then(|x| x.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    obj.insert(
+                        "installed".into(),
+                        json!(is_voice_installed(root, &id)),
+                    );
+                    let origin = obj
+                        .get("origin")
+                        .and_then(|x| x.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let official = obj
+                        .get("official")
+                        .and_then(|x| x.as_bool())
+                        .unwrap_or(true);
+                    let origin_label = if !official {
+                        if origin.is_empty() {
+                            "第三方".to_string()
+                        } else {
+                            format!("第三方 · {origin}")
+                        }
+                    } else if origin.is_empty() {
+                        "图灵镜".to_string()
+                    } else {
+                        origin
+                    };
+                    obj.insert("origin_label".into(), json!(origin_label));
+                    let size = obj.get("size_bytes").and_then(|x| x.as_u64()).unwrap_or(0);
+                    obj.insert("size_label".into(), json!(format_size(size)));
+                }
+            }
+        }
+    }
+    cat
+}
+
+fn format_size(n: u64) -> String {
+    if n == 0 {
+        return String::new();
+    }
+    if n >= 1024 * 1024 * 1024 {
+        return format!("{:.1} GB", n as f64 / (1024.0 * 1024.0 * 1024.0));
+    }
+    if n >= 1024 * 1024 {
+        return format!("{:.0} MB", n as f64 / (1024.0 * 1024.0));
+    }
+    if n >= 1024 {
+        return format!("{:.0} KB", n as f64 / 1024.0);
+    }
+    format!("{n} B")
+}
+
+// ---------------------------------------------------------------------------
+// safe zip extract
+// ---------------------------------------------------------------------------
+
+fn safe_extract_zip(zip_path: &Path, dest: &Path) -> Result<(), String> {
+    fs::create_dir_all(dest).map_err(|e| e.to_string())?;
+    let file = fs::File::open(zip_path).map_err(|e| format!("打开 zip: {e}"))?;
+    let mut archive = zip::ZipArchive::new(file).map_err(|e| format!("无效 zip: {e}"))?;
+    for i in 0..archive.len() {
+        let mut entry = archive
+            .by_index(i)
+            .map_err(|e| format!("zip 条目: {e}"))?;
+        let name = entry.name().replace('\\', "/");
+        if name.is_empty()
+            || name.starts_with('/')
+            || name.starts_with("../")
+            || name.contains("/../")
+        {
+            return Err(format!("音色包路径不安全：{name}"));
+        }
+        if name.split('/').any(|p| p == "..") {
+            return Err(format!("音色包路径不安全：{name}"));
+        }
+        // skip absolute / drive
+        if name.len() > 1 && name.as_bytes().get(1) == Some(&b':') {
+            return Err(format!("音色包含盘符路径：{name}"));
+        }
+        let out_path = dest.join(&name);
+        if entry.is_dir() || name.ends_with('/') {
+            fs::create_dir_all(&out_path).map_err(|e| e.to_string())?;
+            continue;
+        }
+        if let Some(parent) = out_path.parent() {
+            fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+        }
+        let mut outfile = fs::File::create(&out_path).map_err(|e| e.to_string())?;
+        std::io::copy(&mut entry, &mut outfile).map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+fn find_content_root(tmp: &Path) -> PathBuf {
+    // If single top-level dir containing .pth, use it
+    let Ok(rd) = fs::read_dir(tmp) else {
+        return tmp.to_path_buf();
+    };
+    let entries: Vec<_> = rd.flatten().map(|e| e.path()).collect();
+    if entries.len() == 1 && entries[0].is_dir() {
+        return entries[0].clone();
+    }
+    // find dir that has pth
+    if find_first(tmp, "pth").is_some() {
+        return tmp.to_path_buf();
+    }
+    for e in &entries {
+        if e.is_dir() && find_first(e, "pth").is_some() {
+            return e.clone();
+        }
+    }
+    tmp.to_path_buf()
+}
+
+fn find_first(dir: &Path, ext: &str) -> Option<PathBuf> {
+    fn walk(d: &Path, ext: &str, depth: u32) -> Option<PathBuf> {
+        if depth > 4 {
+            return None;
+        }
+        let rd = fs::read_dir(d).ok()?;
+        let mut files = Vec::new();
+        let mut dirs = Vec::new();
+        for e in rd.flatten() {
+            let p = e.path();
+            if p.is_file() {
+                if p.extension()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("")
+                    .eq_ignore_ascii_case(ext)
+                {
+                    files.push(p);
+                }
+            } else if p.is_dir() {
+                dirs.push(p);
+            }
+        }
+        files.sort();
+        if let Some(f) = files.into_iter().next() {
+            return Some(f);
+        }
+        for d in dirs {
+            if let Some(f) = walk(&d, ext, depth + 1) {
+                return Some(f);
+            }
+        }
+        None
+    }
+    walk(dir, ext, 0)
+}
+
+fn write_voice_config(
+    dest_dir: &Path,
+    dest_pth: &Path,
+    name: &str,
+    tag: &str,
+    online_id: &str,
+    index_path: &str,
+    source: &str,
+    official: bool,
+    extra: &Map<String, Value>,
+) -> Value {
+    let mut side = Map::new();
+    side.insert("name".into(), json!(name));
+    side.insert("tag".into(), json!(tag));
+    side.insert(
+        "file".into(),
+        json!(dest_pth.file_name().and_then(|s| s.to_str()).unwrap_or("")),
+    );
+    side.insert("source".into(), json!(source));
+    side.insert("online_id".into(), json!(online_id));
+    side.insert("fabric_official".into(), json!(official));
+    if !index_path.is_empty() {
+        side.insert("index".into(), json!(index_path));
+        side.insert("index_files".into(), json!([index_path]));
+    }
+    for (k, v) in extra {
+        if !side.contains_key(k) {
+            side.insert(k.clone(), v.clone());
+        }
+    }
+    let path = dest_dir.join("config.json");
+    if let Ok(text) = serde_json::to_string_pretty(&Value::Object(side.clone())) {
+        let _ = fs::write(path, text);
+    }
+    json!({
+        "name": name,
+        "path": dest_pth.to_string_lossy(),
+        "file": dest_pth.file_name().and_then(|s| s.to_str()).unwrap_or(""),
+        "dir": dest_dir.to_string_lossy(),
+        "index": index_path,
+        "tag": tag,
+        "source": "user_data",
+        "online_id": online_id,
+    })
+}
+
+/// Install a local voice_pack zip into User_Data/models/<id>/.
+pub fn install_voice_pack_zip(
+    root: &Path,
+    zip_path: &Path,
+    voice_id: &str,
+    display_name: &str,
+    tag: &str,
+    official: bool,
+) -> Result<Value, String> {
+    if !zip_path.is_file() {
+        return Err(format!("找不到音色包：{}", zip_path.display()));
+    }
+    let tmp = paths::update_cache(root).join(format!(
+        "voice_extract_{}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&tmp);
+    fs::create_dir_all(&tmp).map_err(|e| e.to_string())?;
+    let result = (|| {
+        safe_extract_zip(zip_path, &tmp)?;
+        let content = find_content_root(&tmp);
+        let pth = find_first(&content, "pth")
+            .ok_or_else(|| "音色包内没有 .pth 文件".to_string())?;
+        let size = pth.metadata().map(|m| m.len()).unwrap_or(0);
+        if size < MIN_PTH_BYTES {
+            return Err("音色包内 .pth 过小，可能损坏".into());
+        }
+        // optional pack config
+        let pack_cfg = {
+            let cfg = content.join("config.json");
+            if cfg.is_file() {
+                fs::read_to_string(cfg)
+                    .ok()
+                    .and_then(|s| serde_json::from_str::<Value>(&s).ok())
+                    .and_then(|v| v.as_object().cloned())
+                    .unwrap_or_default()
+            } else {
+                Map::new()
+            }
+        };
+        let vid = safe_model_dir_name(
+            if !voice_id.is_empty() {
+                voice_id
+            } else if let Some(s) = pack_cfg
+                .get("voice_id")
+                .or_else(|| pack_cfg.get("id"))
+                .and_then(|v| v.as_str())
+            {
+                s
+            } else if !display_name.is_empty() {
+                display_name
+            } else {
+                zip_path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("voice")
+            },
+        )?;
+        let name = if !display_name.is_empty() {
+            display_name.to_string()
+        } else {
+            pack_cfg
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or(&vid)
+                .to_string()
+        };
+        let tag = if tag.is_empty() {
+            pack_cfg
+                .get("tag")
+                .and_then(|v| v.as_str())
+                .unwrap_or("音色")
+                .to_string()
+        } else {
+            tag.to_string()
+        };
+        let dest_dir = paths::models_dir(root).join(&vid);
+        if dest_dir.is_dir() {
+            // clear previous
+            for e in fs::read_dir(&dest_dir).map_err(|e| e.to_string())? {
+                let p = e.map_err(|e| e.to_string())?.path();
+                if p.is_file() {
+                    let _ = fs::remove_file(&p);
+                } else if p.is_dir() {
+                    let _ = fs::remove_dir_all(&p);
+                }
+            }
+        }
+        fs::create_dir_all(&dest_dir).map_err(|e| e.to_string())?;
+        let dest_pth = dest_dir.join(pth.file_name().unwrap_or_default());
+        fs::copy(&pth, &dest_pth).map_err(|e| format!("复制 pth: {e}"))?;
+
+        let mut index_path = String::new();
+        if let Some(idx) = find_first(&content, "index") {
+            if idx.metadata().map(|m| m.len()).unwrap_or(0) > 1000 {
+                let dest_idx = dest_dir.join(idx.file_name().unwrap_or_default());
+                fs::copy(&idx, &dest_idx).map_err(|e| e.to_string())?;
+                index_path = dest_idx
+                    .canonicalize()
+                    .unwrap_or(dest_idx)
+                    .to_string_lossy()
+                    .into_owned();
+            }
+        }
+        // cover
+        for name in ["cover.png", "cover.jpg", "cover.jpeg", "cover.webp"] {
+            let c = content.join(name);
+            if c.is_file() {
+                let _ = fs::copy(&c, dest_dir.join(name));
+                break;
+            }
+        }
+        // copy profiles if present
+        let prof_src = content.join("profiles");
+        if prof_src.is_dir() {
+            let prof_dst = dest_dir.join("profiles");
+            let _ = fs::create_dir_all(&prof_dst);
+            if let Ok(rd) = fs::read_dir(&prof_src) {
+                for e in rd.flatten() {
+                    let p = e.path();
+                    if p.is_file() {
+                        let _ = fs::copy(&p, prof_dst.join(p.file_name().unwrap_or_default()));
+                    }
+                }
+            }
+        }
+
+        let mut extra = Map::new();
+        for k in ["author", "author_url", "date", "series", "cover"] {
+            if let Some(v) = pack_cfg.get(k) {
+                extra.insert(k.to_string(), v.clone());
+            }
+        }
+        let source = if official {
+            "online_pack"
+        } else {
+            "thirdparty_pack"
+        };
+        Ok(write_voice_config(
+            &dest_dir,
+            &dest_pth,
+            &name,
+            &tag,
+            &vid,
+            &index_path,
+            source,
+            official,
+            &extra,
+        ))
+    })();
+    let _ = fs::remove_dir_all(&tmp);
+    result
+}
+
+/// Download + install one catalog voice entry.
+pub fn install_voice_entry(
+    app: AppHandle,
+    root: PathBuf,
+    entry: Value,
+) -> Result<Value, String> {
+    STORE_CANCEL.store(false, Ordering::SeqCst);
+    let id = entry
+        .get("id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let name = entry
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or(&id)
+        .to_string();
+    let tag = entry
+        .get("tag")
+        .and_then(|v| v.as_str())
+        .unwrap_or("音色")
+        .to_string();
+    let official = entry
+        .get("official")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
+    let pack_url = entry
+        .get("pack_url")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let pth_url = entry
+        .get("pth_url")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let sha = entry
+        .get("sha256")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let size = entry
+        .get("size_bytes")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+
+    let emit = |phase: &str, done: u64, total: u64, message: &str| {
+        let _ = app.emit(
+            "store-progress",
+            json!({
+                "voice_id": id,
+                "phase": phase,
+                "done": done,
+                "total": total,
+                "percent": if total > 0 { (done as f64 / total as f64 * 100.0) as u32 } else { 0 },
+                "message": message,
+            }),
+        );
+    };
+
+    emit("start", 0, size.max(1), &format!("开始下载 {name}…"));
+
+    if !pack_url.is_empty() {
+        let cache = paths::update_cache(&root).join("voice_packs");
+        fs::create_dir_all(&cache).map_err(|e| e.to_string())?;
+        let vid = safe_model_dir_name(if id.is_empty() { &name } else { &id })?;
+        let zpath = cache.join(format!("{vid}.zip"));
+        let cancel = Arc::new(AtomicBool::new(false));
+        let cancel_flag = cancel.clone();
+        // poll STORE_CANCEL into this flag
+        let poll = std::thread::spawn({
+            let cancel = cancel.clone();
+            move || {
+                while !cancel.load(Ordering::SeqCst) {
+                    if STORE_CANCEL.load(Ordering::SeqCst) {
+                        cancel.store(true, Ordering::SeqCst);
+                        break;
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(200));
+                }
+            }
+        });
+
+        let app2 = app.clone();
+        let id2 = id.clone();
+        let progress: download::ProgressFn = Arc::new(move |done, total, msg| {
+            let _ = app2.emit(
+                "store-progress",
+                json!({
+                    "voice_id": id2,
+                    "phase": "download",
+                    "done": done,
+                    "total": total,
+                    "percent": if total > 0 { (done as f64 / total as f64 * 100.0) as u32 } else { 0 },
+                    "message": msg,
+                }),
+            );
+        });
+
+        let res = download::download_request(
+            DownloadRequest {
+                urls: vec![pack_url],
+                dest: zpath.clone(),
+                expected_sha256: sha,
+                size_hint: size,
+                connections: None,
+                kind: DownloadKind::VoicePack,
+            },
+            cancel_flag,
+            Some(progress),
+        );
+        cancel.store(true, Ordering::SeqCst);
+        let _ = poll.join();
+        res?;
+        emit("extract", 0, 1, "正在解压安装…");
+        let info = install_voice_pack_zip(&root, &zpath, &id, &name, &tag, official)?;
+        emit("done", 1, 1, "安装完成");
+        return Ok(info);
+    }
+
+    if pth_url.is_empty() {
+        return Err("音色未配置下载地址".into());
+    }
+    // multi-file install
+    let vid = safe_model_dir_name(if id.is_empty() { &name } else { &id })?;
+    let dest_dir = paths::models_dir(&root).join(&vid);
+    fs::create_dir_all(&dest_dir).map_err(|e| e.to_string())?;
+    let cache = paths::update_cache(&root).join("voices").join(&vid);
+    fs::create_dir_all(&cache).map_err(|e| e.to_string())?;
+    let pth_tmp = cache.join(format!("{vid}.pth"));
+
+    let cancel = Arc::new(AtomicBool::new(false));
+    let app2 = app.clone();
+    let id2 = id.clone();
+    let progress: download::ProgressFn = Arc::new(move |done, total, msg| {
+        let _ = app2.emit(
+            "store-progress",
+            json!({
+                "voice_id": id2,
+                "phase": "pth",
+                "done": done,
+                "total": total,
+                "percent": if total > 0 { (done as f64 / total as f64 * 100.0) as u32 } else { 0 },
+                "message": msg,
+            }),
+        );
+    });
+    download::download_request(
+        DownloadRequest {
+            urls: vec![pth_url],
+            dest: pth_tmp.clone(),
+            expected_sha256: sha,
+            size_hint: size,
+            connections: None,
+            kind: DownloadKind::VoicePack,
+        },
+        cancel.clone(),
+        Some(progress),
+    )?;
+    if pth_tmp.metadata().map(|m| m.len()).unwrap_or(0) < MIN_PTH_BYTES {
+        return Err("下载的模型文件过小，可能不是有效 .pth".into());
+    }
+    // clear old pths
+    if let Ok(rd) = fs::read_dir(&dest_dir) {
+        for e in rd.flatten() {
+            let p = e.path();
+            if p.extension()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+                .eq_ignore_ascii_case("pth")
+            {
+                let _ = fs::remove_file(p);
+            }
+        }
+    }
+    let dest_pth = dest_dir.join(format!("{vid}.pth"));
+    fs::copy(&pth_tmp, &dest_pth).map_err(|e| e.to_string())?;
+
+    let mut index_path = String::new();
+    if let Some(iu) = entry.get("index_url").and_then(|v| v.as_str()) {
+        if !iu.is_empty() {
+            let idx_tmp = cache.join(format!("{vid}.index"));
+            let _ = download::download_request(
+                DownloadRequest {
+                    urls: vec![iu.to_string()],
+                    dest: idx_tmp.clone(),
+                    expected_sha256: String::new(),
+                    size_hint: 0,
+                    connections: Some(1),
+                    kind: DownloadKind::Generic,
+                },
+                cancel.clone(),
+                None,
+            );
+            if idx_tmp.is_file() && idx_tmp.metadata().map(|m| m.len()).unwrap_or(0) > 1000 {
+                let dest_idx = dest_dir.join(format!("{vid}.index"));
+                let _ = fs::copy(&idx_tmp, &dest_idx);
+                index_path = dest_idx.to_string_lossy().into_owned();
+            }
+        }
+    }
+
+    let mut extra = Map::new();
+    for k in ["author", "author_url", "date", "series"] {
+        if let Some(v) = entry.get(k) {
+            extra.insert(k.to_string(), v.clone());
+        }
+    }
+    let source = if official {
+        "online_files"
+    } else {
+        "thirdparty_files"
+    };
+    let info = write_voice_config(
+        &dest_dir,
+        &dest_pth,
+        &name,
+        &tag,
+        &vid,
+        &index_path,
+        source,
+        official,
+        &extra,
+    );
+    emit("done", 1, 1, "安装完成");
+    Ok(info)
+}
+
+pub fn cancel_store_download() {
+    STORE_CANCEL.store(true, Ordering::SeqCst);
+}
+
+

--- a/app/src-tauri/src/voices.rs
+++ b/app/src-tauri/src/voices.rs
@@ -1,0 +1,1585 @@
+//! Local voice catalog: list / select / import / index / profiles / delete.
+//! Mirrors launcher/catalog.py + profiles.py behaviour (disk layout only).
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use regex::Regex;
+use serde_json::{json, Map, Value};
+
+use crate::paths;
+
+const MIN_MODEL_BYTES: u64 = 200 * 1024;
+const PROFILE_EXT: &str = ".tmvp";
+const PROFILES_DIR: &str = "profiles";
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+fn read_json(path: &Path) -> Value {
+    if !path.is_file() {
+        return json!({});
+    }
+    match fs::read_to_string(path) {
+        Ok(s) => serde_json::from_str(&s).unwrap_or_else(|_| json!({})),
+        Err(_) => json!({}),
+    }
+}
+
+fn write_json_atomic(path: &Path, data: &Value) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let text = serde_json::to_string_pretty(data).map_err(|e| e.to_string())?;
+    let tmp = path.with_extension(format!(
+        "tmp.{}",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    {
+        let mut f = fs::File::create(&tmp).map_err(|e| e.to_string())?;
+        f.write_all(text.as_bytes()).map_err(|e| e.to_string())?;
+        f.sync_all().ok();
+    }
+    fs::rename(&tmp, path).map_err(|e| {
+        let _ = fs::remove_file(&tmp);
+        e.to_string()
+    })?;
+    Ok(())
+}
+
+fn load_app_config(root: &Path) -> Map<String, Value> {
+    let v = read_json(&paths::app_config_path(root));
+    v.as_object().cloned().unwrap_or_default()
+}
+
+fn save_app_config(root: &Path, cfg: &Map<String, Value>) -> Result<(), String> {
+    write_json_atomic(&paths::app_config_path(root), &Value::Object(cfg.clone()))
+}
+
+pub fn safe_model_dir_name(name: &str) -> Result<String, String> {
+    let re = Regex::new(r"[^\w\u4e00-\u9fff\-]+").unwrap();
+    let n = re.replace_all(name.trim(), "_");
+    let n = n.trim_matches(|c| c == '.' || c == '_');
+    if n.is_empty() || n == "." || n == ".." {
+        return Err(format!("invalid model name: {name:?}"));
+    }
+    Ok(n.chars().take(80).collect())
+}
+
+fn guess_tag(name: &str) -> &'static str {
+    let n = name.to_lowercase();
+    if ["女", "girl", "loli", "萝莉", "少女"]
+        .iter()
+        .any(|k| n.contains(k) || name.contains(k))
+    {
+        return "少女音";
+    }
+    if ["男", "boy", "男声", "青年"]
+        .iter()
+        .any(|k| n.contains(k) || name.contains(k))
+    {
+        return "男声";
+    }
+    if name.contains("御姐") {
+        return "御姐音";
+    }
+    "音色"
+}
+
+fn find_pth(folder: &Path) -> Option<PathBuf> {
+    let mut pths: Vec<PathBuf> = fs::read_dir(folder)
+        .ok()?
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|s| s.to_str()).unwrap_or("") == "pth")
+        .collect();
+    pths.sort();
+    pths.into_iter().next()
+}
+
+fn find_cover(folder: &Path) -> Option<String> {
+    for ext in [".png", ".jpg", ".jpeg", ".webp"] {
+        if let Ok(rd) = fs::read_dir(folder) {
+            for e in rd.flatten() {
+                let p = e.path();
+                let name = p.file_name().and_then(|s| s.to_str()).unwrap_or("");
+                if name.eq_ignore_ascii_case(&format!("cover{ext}"))
+                    || name.to_ascii_lowercase().ends_with(ext)
+                {
+                    if p.is_file() {
+                        return Some(p.to_string_lossy().into_owned());
+                    }
+                }
+            }
+        }
+        let c = folder.join(format!("cover{ext}"));
+        if c.is_file() {
+            return Some(c.to_string_lossy().into_owned());
+        }
+    }
+    None
+}
+
+fn resolve_cover(cover: &str, model_dir: Option<&Path>, voice_id: &str, root: &Path) -> String {
+    let cover = cover.trim().replace('\\', "/");
+    if cover.is_empty() {
+        return String::new();
+    }
+    if cover.to_ascii_lowercase().starts_with("http://")
+        || cover.to_ascii_lowercase().starts_with("https://")
+    {
+        return cover;
+    }
+    let cp = PathBuf::from(&cover);
+    if cp.is_file() {
+        return cp.to_string_lossy().into_owned();
+    }
+    let mut rel = cover.clone();
+    if rel.to_ascii_lowercase().starts_with("ch-banner/") {
+        rel = rel["ch-banner/".len()..].to_string();
+    }
+    for base in [paths::ch_banner_dir(root), root.join("ch-banner")] {
+        let cand = base.join(&rel);
+        if cand.is_file() {
+            return cand.to_string_lossy().into_owned();
+        }
+        let stem = Path::new(&rel)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or(voice_id);
+        if !stem.is_empty() {
+            for ext in [".jpg", ".jpeg", ".png", ".webp"] {
+                let c2 = base.join(format!("{stem}{ext}"));
+                if c2.is_file() {
+                    return c2.to_string_lossy().into_owned();
+                }
+            }
+        }
+    }
+    if let Some(md) = model_dir {
+        let cand = md.join(&cover);
+        if cand.is_file() {
+            return cand.to_string_lossy().into_owned();
+        }
+        if let Some(f) = find_cover(md) {
+            return f;
+        }
+    }
+    String::new()
+}
+
+fn model_is_broken(pth: Option<&Path>) -> bool {
+    match pth {
+        None => true,
+        Some(p) if !p.is_file() => true,
+        Some(p) => p.metadata().map(|m| m.len() < MIN_MODEL_BYTES).unwrap_or(true),
+    }
+}
+
+fn looks_like_voice_folder(folder: &Path) -> bool {
+    (folder.join("config.json")).is_file() || find_cover(folder).is_some()
+}
+
+fn read_sidecar(folder: &Path) -> Map<String, Value> {
+    let v = read_json(&folder.join("config.json"));
+    v.as_object().cloned().unwrap_or_default()
+}
+
+fn write_sidecar(folder: &Path, side: &Map<String, Value>) -> Result<(), String> {
+    write_json_atomic(&folder.join("config.json"), &Value::Object(side.clone()))
+}
+
+fn path_inside_dir(path: &Path, folder: &Path) -> bool {
+    let Ok(p) = path.canonicalize() else {
+        return false;
+    };
+    let Ok(f) = folder.canonicalize() else {
+        return false;
+    };
+    p.starts_with(&f)
+}
+
+fn ensure_index_in_model_dir(model_dir: &Path, index_src: &Path) -> Result<String, String> {
+    if !index_src.is_file()
+        || index_src
+            .extension()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_ascii_lowercase()
+            != "index"
+    {
+        return Err(format!("not a .index file: {}", index_src.display()));
+    }
+    fs::create_dir_all(model_dir).map_err(|e| e.to_string())?;
+    if path_inside_dir(index_src, model_dir) {
+        return Ok(index_src
+            .canonicalize()
+            .unwrap_or_else(|_| index_src.to_path_buf())
+            .to_string_lossy()
+            .into_owned());
+    }
+    let dest = model_dir.join(
+        index_src
+            .file_name()
+            .ok_or_else(|| "index name".to_string())?,
+    );
+    if !dest.is_file()
+        || dest.canonicalize().ok() != index_src.canonicalize().ok()
+    {
+        fs::copy(index_src, &dest).map_err(|e| format!("copy index: {e}"))?;
+    }
+    Ok(dest
+        .canonicalize()
+        .unwrap_or(dest)
+        .to_string_lossy()
+        .into_owned())
+}
+
+// ---------------------------------------------------------------------------
+// list
+// ---------------------------------------------------------------------------
+
+fn resolve_active_index(model_dir: &Path, side: &Map<String, Value>) -> String {
+    // Prefer config index if file exists
+    if let Some(idx) = side.get("index").and_then(|v| v.as_str()) {
+        let p = PathBuf::from(idx.trim());
+        if p.is_file() {
+            // Prefer same-name local twin
+            let local = model_dir.join(p.file_name().unwrap_or_default());
+            if local.is_file() {
+                return local
+                    .canonicalize()
+                    .unwrap_or(local)
+                    .to_string_lossy()
+                    .into_owned();
+            }
+            return p
+                .canonicalize()
+                .unwrap_or(p)
+                .to_string_lossy()
+                .into_owned();
+        }
+    }
+    // Any local *.index
+    if let Ok(rd) = fs::read_dir(model_dir) {
+        let mut idxs: Vec<PathBuf> = rd
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| {
+                p.extension()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("")
+                    .eq_ignore_ascii_case("index")
+            })
+            .collect();
+        idxs.sort();
+        if let Some(p) = idxs.into_iter().next() {
+            return p
+                .canonicalize()
+                .unwrap_or(p)
+                .to_string_lossy()
+                .into_owned();
+        }
+    }
+    String::new()
+}
+
+fn list_user_data(root: &Path) -> Vec<Value> {
+    let models_root = paths::models_dir(root);
+    let mut out = Vec::new();
+    let Ok(rd) = fs::read_dir(&models_root) else {
+        return out;
+    };
+    let mut folders: Vec<PathBuf> = rd
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.is_dir())
+        .filter(|p| {
+            !p.file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+                .starts_with('.')
+        })
+        .collect();
+    folders.sort();
+    for folder in folders {
+        let pth = find_pth(&folder);
+        let side = read_sidecar(&folder);
+        let vid = folder
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_string();
+        let name = side
+            .get("name")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .unwrap_or(&vid)
+            .to_string();
+        let tag = side
+            .get("tag")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| guess_tag(&name).to_string());
+        let author = side
+            .get("author")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let author_url = side
+            .get("author_url")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let mut cover = side
+            .get("cover")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        cover = resolve_cover(&cover, Some(&folder), &vid, root);
+        if cover.is_empty() {
+            cover = find_cover(&folder).unwrap_or_default();
+        }
+
+        if pth.is_none() {
+            if !looks_like_voice_folder(&folder) {
+                continue;
+            }
+            out.push(json!({
+                "name": name,
+                "path": "",
+                "file": "",
+                "dir": folder.to_string_lossy(),
+                "cover": cover,
+                "index": "",
+                "has_index": false,
+                "tag": tag,
+                "author": author,
+                "author_url": author_url,
+                "source": "user_data",
+                "missing": true,
+            }));
+            continue;
+        }
+        let pth = pth.unwrap();
+        let broken = model_is_broken(Some(&pth));
+        let index = resolve_active_index(&folder, &side);
+        let mut entry = json!({
+            "name": name,
+            "path": pth.to_string_lossy(),
+            "file": pth.file_name().and_then(|s| s.to_str()).unwrap_or(""),
+            "dir": folder.to_string_lossy(),
+            "cover": cover,
+            "index": index,
+            "has_index": !index.is_empty(),
+            "tag": tag,
+            "author": author,
+            "author_url": author_url,
+            "source": "user_data",
+            "missing": broken,
+        });
+        // voice params if present
+        if let Some(obj) = entry.as_object_mut() {
+            for k in [
+                "pitch",
+                "formant",
+                "index_rate",
+                "rms_mix_rate",
+                "threhold",
+                "f0method",
+            ] {
+                if let Some(v) = side.get(k) {
+                    if !v.is_null() && v != "" {
+                        obj.insert(k.to_string(), v.clone());
+                    }
+                }
+            }
+            if let Some(ap) = side.get("active_profile") {
+                obj.insert("active_profile".into(), ap.clone());
+            }
+        }
+        out.push(entry);
+    }
+    out
+}
+
+fn list_legacy(root: &Path) -> Vec<Value> {
+    let weights = paths::engine_weights(root);
+    let mut out = Vec::new();
+    let Ok(rd) = fs::read_dir(&weights) else {
+        return out;
+    };
+    let mut pths: Vec<PathBuf> = rd
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| {
+            p.extension()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+                .eq_ignore_ascii_case("pth")
+        })
+        .collect();
+    pths.sort();
+    for p in pths {
+        let name = p
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("voice")
+            .to_string();
+        let mut cover = String::new();
+        for ext in [".png", ".jpg", ".jpeg", ".webp"] {
+            let c = p.with_extension(&ext[1..]);
+            if c.is_file() {
+                cover = c.to_string_lossy().into_owned();
+                break;
+            }
+        }
+        out.push(json!({
+            "name": name,
+            "path": p.to_string_lossy(),
+            "file": p.file_name().and_then(|s| s.to_str()).unwrap_or(""),
+            "dir": weights.to_string_lossy(),
+            "cover": cover,
+            "index": "",
+            "has_index": false,
+            "tag": guess_tag(&name),
+            "author": "",
+            "author_url": "",
+            "source": "legacy_weights",
+            "missing": model_is_broken(Some(&p)),
+        }));
+    }
+    out
+}
+
+/// Full local catalog (User_Data first, then legacy weights not already present).
+pub fn list_voices(root: &Path) -> Value {
+    let _ = paths::ensure_user_dirs(root);
+    let mut primary = list_user_data(root);
+    let mut seen_paths: std::collections::HashSet<String> = primary
+        .iter()
+        .filter_map(|m| m.get("path").and_then(|v| v.as_str()))
+        .filter(|s| !s.is_empty())
+        .map(|s| {
+            PathBuf::from(s)
+                .canonicalize()
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_else(|_| s.to_string())
+        })
+        .collect();
+    let mut seen_stems: std::collections::HashSet<String> = primary
+        .iter()
+        .filter_map(|m| m.get("file").and_then(|v| v.as_str()))
+        .map(|s| s.to_ascii_lowercase())
+        .collect();
+
+    for m in list_legacy(root) {
+        let path = m.get("path").and_then(|v| v.as_str()).unwrap_or("");
+        let file = m.get("file").and_then(|v| v.as_str()).unwrap_or("");
+        let rp = PathBuf::from(path)
+            .canonicalize()
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_else(|_| path.to_string());
+        let stem = file.to_ascii_lowercase();
+        if seen_paths.contains(&rp) || seen_stems.contains(&stem) {
+            continue;
+        }
+        seen_paths.insert(rp);
+        seen_stems.insert(stem);
+        primary.push(m);
+    }
+
+    let cfg = load_app_config(root);
+    let selected_path = cfg
+        .get("last_model_path")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let selected_name = cfg
+        .get("last_model_name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let selected_file = cfg
+        .get("last_model")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let mut selected_idx: i64 = -1;
+    for (i, m) in primary.iter().enumerate() {
+        let path = m.get("path").and_then(|v| v.as_str()).unwrap_or("");
+        let name = m.get("name").and_then(|v| v.as_str()).unwrap_or("");
+        let file = m.get("file").and_then(|v| v.as_str()).unwrap_or("");
+        if (!selected_path.is_empty() && path == selected_path)
+            || (!selected_file.is_empty() && file == selected_file)
+            || (!selected_name.is_empty() && name == selected_name)
+        {
+            selected_idx = i as i64;
+            break;
+        }
+    }
+    if selected_idx < 0 && !primary.is_empty() {
+        selected_idx = 0;
+    }
+
+    let recents = cfg
+        .get("recent_models")
+        .cloned()
+        .unwrap_or_else(|| json!([]));
+
+    json!({
+        "models": primary,
+        "selected_idx": selected_idx,
+        "models_dir": paths::models_dir(root).to_string_lossy(),
+        "recent_keys": recents,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// select
+// ---------------------------------------------------------------------------
+
+fn model_key(m: &Value) -> String {
+    let path = m.get("path").and_then(|v| v.as_str()).unwrap_or("");
+    if !path.is_empty() {
+        return path.to_string();
+    }
+    let dir = m.get("dir").and_then(|v| v.as_str()).unwrap_or("");
+    let name = m.get("name").and_then(|v| v.as_str()).unwrap_or("");
+    format!("{dir}|{name}")
+}
+
+pub fn select_voice(root: &Path, path: &str, dir: &str, name: &str) -> Result<Value, String> {
+    let cat = list_voices(root);
+    let models = cat
+        .get("models")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let mut found: Option<Value> = None;
+    for m in &models {
+        let mp = m.get("path").and_then(|v| v.as_str()).unwrap_or("");
+        let md = m.get("dir").and_then(|v| v.as_str()).unwrap_or("");
+        let mn = m.get("name").and_then(|v| v.as_str()).unwrap_or("");
+        if (!path.is_empty() && mp == path)
+            || (!dir.is_empty() && !name.is_empty() && md == dir && mn == name)
+            || (!name.is_empty() && mn == name && path.is_empty() && dir.is_empty())
+        {
+            found = Some(m.clone());
+            break;
+        }
+    }
+    let m = found.ok_or_else(|| "未找到该音色".to_string())?;
+    if m.get("missing").and_then(|v| v.as_bool()).unwrap_or(false) {
+        return Err("音色文件缺失或不完整".into());
+    }
+    let mut cfg = load_app_config(root);
+    cfg.insert(
+        "last_model".into(),
+        json!(m.get("file").and_then(|v| v.as_str()).unwrap_or("")),
+    );
+    cfg.insert(
+        "last_model_name".into(),
+        json!(m.get("name").and_then(|v| v.as_str()).unwrap_or("")),
+    );
+    cfg.insert(
+        "last_model_path".into(),
+        json!(m.get("path").and_then(|v| v.as_str()).unwrap_or("")),
+    );
+    let key = model_key(&m);
+    let mut recents: Vec<String> = cfg
+        .get("recent_models")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|x| x.as_str().map(|s| s.to_string()))
+                .filter(|s| s != &key)
+                .collect()
+        })
+        .unwrap_or_default();
+    recents.insert(0, key);
+    recents.truncate(12);
+    cfg.insert("recent_models".into(), json!(recents));
+
+    // Apply profile / voice params into app config for dock
+    if let Some(md) = m.get("dir").and_then(|v| v.as_str()) {
+        if m.get("source").and_then(|v| v.as_str()) == Some("user_data") {
+            apply_profile_to_cfg(md, &mut cfg);
+        }
+    }
+    // Fallback voice params from model entry
+    for k in ["pitch", "formant", "index_rate", "rms_mix_rate", "threhold", "f0method"] {
+        if let Some(v) = m.get(k) {
+            if !v.is_null() && cfg.get(k).is_none() {
+                cfg.insert(k.to_string(), v.clone());
+            }
+        }
+    }
+
+    save_app_config(root, &cfg)?;
+
+    // Sync engine inuse config if present
+    let _ = sync_inuse_model(
+        root,
+        m.get("path").and_then(|v| v.as_str()).unwrap_or(""),
+        m.get("index").and_then(|v| v.as_str()).unwrap_or(""),
+    );
+
+    Ok(json!({
+        "ok": true,
+        "model": m,
+        "pitch": cfg.get("pitch").cloned().unwrap_or(json!(0)),
+        "formant": cfg.get("formant").cloned().unwrap_or(json!(0.0)),
+        "active_profile": cfg.get("_active_profile_name").cloned().unwrap_or(json!("")),
+        "profile_summary": profile_summary_from_cfg(&cfg),
+    }))
+}
+
+fn sync_inuse_model(root: &Path, pth: &str, index: &str) -> Result<(), String> {
+    if pth.is_empty() {
+        return Ok(());
+    }
+    let path = root.join("configs").join("inuse").join("config.json");
+    if !path.is_file() {
+        return Ok(());
+    }
+    let mut data = read_json(&path);
+    if let Some(obj) = data.as_object_mut() {
+        obj.insert("pth_path".into(), json!(pth));
+        obj.insert("index_path".into(), json!(index));
+    }
+    write_json_atomic(&path, &data)
+}
+
+fn profile_summary_from_cfg(cfg: &Map<String, Value>) -> String {
+    let name = cfg
+        .get("_active_profile_name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let pitch = cfg
+        .get("pitch")
+        .and_then(|v| v.as_i64())
+        .or_else(|| cfg.get("pitch").and_then(|v| v.as_f64()).map(|f| f as i64))
+        .unwrap_or(0);
+    let formant = cfg.get("formant").and_then(|v| v.as_f64()).unwrap_or(0.0);
+    let label = if name.is_empty() {
+        "默认（原始参数）".to_string()
+    } else {
+        name.to_string()
+    };
+    if pitch == 0 && (formant - 0.0).abs() < 0.001 {
+        label
+    } else {
+        let sign = if pitch >= 0 { "+" } else { "" };
+        format!("{label} · 音高 {sign}{pitch} 共鸣 {formant:.2}")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// index bindings
+// ---------------------------------------------------------------------------
+
+pub fn list_index_bindings(root: &Path, model_dir: &str) -> Result<Value, String> {
+    let md = PathBuf::from(model_dir);
+    guard_model_dir(root, &md)?;
+    let mut side = read_sidecar(&md);
+    let mut files: Vec<String> = Vec::new();
+    // local *.index
+    if let Ok(rd) = fs::read_dir(&md) {
+        for e in rd.flatten() {
+            let p = e.path();
+            if p.extension()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+                .eq_ignore_ascii_case("index")
+            {
+                files.push(
+                    p.canonicalize()
+                        .unwrap_or(p)
+                        .to_string_lossy()
+                        .into_owned(),
+                );
+            }
+        }
+    }
+    if let Some(arr) = side.get("index_files").and_then(|v| v.as_array()) {
+        for v in arr {
+            if let Some(s) = v.as_str() {
+                let p = PathBuf::from(s);
+                if p.is_file() {
+                    let rp = p
+                        .canonicalize()
+                        .unwrap_or(p)
+                        .to_string_lossy()
+                        .into_owned();
+                    if !files.iter().any(|x| x == &rp) {
+                        files.push(rp);
+                    }
+                }
+            }
+        }
+    }
+    files.sort();
+    let active = resolve_active_index(&md, &side);
+    side.insert("index_files".into(), json!(files));
+    side.insert("index".into(), json!(active));
+    let _ = write_sidecar(&md, &side);
+
+    let items: Vec<Value> = std::iter::once(json!({
+        "path": "",
+        "label": "不用检索库（仅 .pth）",
+        "badge": "",
+        "active": active.is_empty(),
+    }))
+    .chain(files.iter().map(|p| {
+        let pb = PathBuf::from(p);
+        let label = pb
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or(p)
+            .to_string();
+        let badge = if path_inside_dir(&pb, &md) {
+            "当前音色目录".to_string()
+        } else {
+            pb.parent()
+                .map(|x| x.to_string_lossy().into_owned())
+                .unwrap_or_default()
+        };
+        let is_active = !active.is_empty()
+            && (active == *p
+                || PathBuf::from(&active).canonicalize().ok()
+                    == pb.canonicalize().ok());
+        json!({
+            "path": p,
+            "label": label,
+            "badge": badge,
+            "active": is_active,
+        })
+    }))
+    .collect();
+
+    Ok(json!({ "items": items, "active": active, "model_dir": model_dir }))
+}
+
+fn guard_model_dir(root: &Path, md: &Path) -> Result<(), String> {
+    let models = paths::models_dir(root);
+    let Ok(md_c) = md.canonicalize() else {
+        return Err("音色目录不存在".into());
+    };
+    let Ok(root_c) = models.canonicalize() else {
+        return Err("models 目录不存在".into());
+    };
+    if !md_c.starts_with(&root_c) {
+        return Err("路径不在音色库内".into());
+    }
+    Ok(())
+}
+
+pub fn set_active_index(root: &Path, model_dir: &str, index_path: &str) -> Result<Value, String> {
+    let md = PathBuf::from(model_dir);
+    guard_model_dir(root, &md)?;
+    let mut side = read_sidecar(&md);
+    if index_path.trim().is_empty() {
+        side.insert("index".into(), json!(""));
+        write_sidecar(&md, &side)?;
+        return list_index_bindings(root, model_dir);
+    }
+    let local = ensure_index_in_model_dir(&md, Path::new(index_path))?;
+    let mut files: Vec<String> = side
+        .get("index_files")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|x| x.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    if !files.iter().any(|f| f == &local) {
+        files.push(local.clone());
+    }
+    side.insert("index_files".into(), json!(files));
+    side.insert("index".into(), json!(local));
+    write_sidecar(&md, &side)?;
+    // Keep app selection in sync if this is current model
+    let cfg = load_app_config(root);
+    if cfg.get("last_model_path").and_then(|v| v.as_str()).unwrap_or("")
+        == find_pth(&md)
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_default()
+    {
+        let _ = sync_inuse_model(
+            root,
+            cfg.get("last_model_path")
+                .and_then(|v| v.as_str())
+                .unwrap_or(""),
+            &local,
+        );
+    }
+    list_index_bindings(root, model_dir)
+}
+
+pub fn bind_index_file(root: &Path, model_dir: &str, index_src: &str) -> Result<Value, String> {
+    let md = PathBuf::from(model_dir);
+    guard_model_dir(root, &md)?;
+    let local = ensure_index_in_model_dir(&md, Path::new(index_src))?;
+    let mut side = read_sidecar(&md);
+    let mut files: Vec<String> = side
+        .get("index_files")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|x| x.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    if !files.iter().any(|f| f == &local) {
+        files.push(local.clone());
+    }
+    side.insert("index_files".into(), json!(files));
+    side.insert("index".into(), json!(local));
+    write_sidecar(&md, &side)?;
+    list_index_bindings(root, model_dir)
+}
+
+pub fn unbind_index(root: &Path, model_dir: &str, index_path: &str) -> Result<Value, String> {
+    let md = PathBuf::from(model_dir);
+    guard_model_dir(root, &md)?;
+    let mut side = read_sidecar(&md);
+    let target = PathBuf::from(index_path)
+        .canonicalize()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| index_path.to_string());
+    let files: Vec<String> = side
+        .get("index_files")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|x| x.as_str().map(|s| s.to_string()))
+                .filter(|s| {
+                    let rp = PathBuf::from(s)
+                        .canonicalize()
+                        .map(|p| p.to_string_lossy().into_owned())
+                        .unwrap_or_else(|_| s.clone());
+                    rp != target
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    side.insert("index_files".into(), json!(files));
+    let active = side
+        .get("index")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let active_r = PathBuf::from(&active)
+        .canonicalize()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or(active);
+    if active_r == target {
+        side.insert("index".into(), json!(""));
+    }
+    write_sidecar(&md, &side)?;
+    list_index_bindings(root, model_dir)
+}
+
+pub fn pick_index_file() -> Option<String> {
+    rfd::FileDialog::new()
+        .add_filter("特征索引", &["index"])
+        .add_filter("全部", &["*"])
+        .set_title("选择特征索引文件 (.index)")
+        .pick_file()
+        .map(|p| p.to_string_lossy().into_owned())
+}
+
+// ---------------------------------------------------------------------------
+// profiles
+// ---------------------------------------------------------------------------
+
+fn profiles_dir(model_dir: &Path) -> PathBuf {
+    model_dir.join(PROFILES_DIR)
+}
+
+fn source_label(src: &str) -> String {
+    match src {
+        "default" => "原始".into(),
+        "self" => "自建".into(),
+        "import" => "导入".into(),
+        "official" => "官方优化".into(),
+        other => other.to_string(),
+    }
+}
+
+fn apply_profile_to_cfg(model_dir: &str, cfg: &mut Map<String, Value>) {
+    let md = PathBuf::from(model_dir);
+    let side = read_sidecar(&md);
+    let pid = side
+        .get("active_profile")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    cfg.insert("_active_profile_id".into(), json!(pid));
+    if pid.is_empty() {
+        cfg.insert("_active_profile_name".into(), json!(""));
+        // model inline params
+        for k in ["pitch", "formant", "index_rate", "rms_mix_rate", "threhold", "f0method"] {
+            if let Some(v) = side.get(k) {
+                if !v.is_null() {
+                    cfg.insert(k.to_string(), v.clone());
+                }
+            }
+        }
+        return;
+    }
+    let path = profiles_dir(&md).join(format!("{pid}{PROFILE_EXT}"));
+    let prof = read_json(&path);
+    if !prof.is_object() {
+        cfg.insert("_active_profile_name".into(), json!(""));
+        return;
+    }
+    let name = prof
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("档案")
+        .to_string();
+    cfg.insert("_active_profile_name".into(), json!(name));
+    for group in ["voice", "fx", "perf"] {
+        if let Some(g) = prof.get(group).and_then(|v| v.as_object()) {
+            for (k, v) in g {
+                cfg.insert(k.clone(), v.clone());
+            }
+        }
+    }
+}
+
+pub fn list_profiles(root: &Path, model_dir: &str) -> Result<Value, String> {
+    let md = PathBuf::from(model_dir);
+    guard_model_dir(root, &md)?;
+    let side = read_sidecar(&md);
+    let active = side
+        .get("active_profile")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let mut items = vec![json!({
+        "id": "",
+        "name": "默认（原始参数）",
+        "source": "default",
+        "source_label": "原始",
+        "score": null,
+        "active": active.is_empty(),
+        "desc": "",
+    })];
+
+    let dir = profiles_dir(&md);
+    if let Ok(rd) = fs::read_dir(&dir) {
+        let mut files: Vec<PathBuf> = rd
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| {
+                p.extension()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("")
+                    .eq_ignore_ascii_case("tmvp")
+                    || p.file_name()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or("")
+                        .ends_with(PROFILE_EXT)
+            })
+            .collect();
+        files.sort();
+        for f in files {
+            let stem = f
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+                .to_string();
+            let prof = read_json(&f);
+            let name = prof
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or(&stem)
+                .to_string();
+            let src = prof
+                .get("meta")
+                .and_then(|v| v.get("source"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("self")
+                .to_string();
+            let score = prof
+                .get("meta")
+                .and_then(|v| v.get("score"))
+                .cloned()
+                .unwrap_or(Value::Null);
+            let voice = prof.get("voice").and_then(|v| v.as_object());
+            let pitch = voice
+                .and_then(|v| v.get("pitch"))
+                .and_then(|v| v.as_i64().or_else(|| v.as_f64().map(|f| f as i64)))
+                .unwrap_or(0);
+            let formant = voice
+                .and_then(|v| v.get("formant"))
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.0);
+            let mut desc = format!("音高 {pitch:+} · 共鸣 {formant:.2}");
+            if let Some(s) = score.as_f64() {
+                desc = format!("{desc} · 相似度 {s:.2}");
+            }
+            items.push(json!({
+                "id": stem,
+                "name": name,
+                "source": src,
+                "source_label": source_label(&src),
+                "score": score,
+                "active": active == stem,
+                "desc": desc,
+            }));
+        }
+    }
+
+    Ok(json!({
+        "items": items,
+        "active_id": active,
+        "model_dir": model_dir,
+    }))
+}
+
+pub fn set_active_profile(
+    root: &Path,
+    model_dir: &str,
+    profile_id: &str,
+) -> Result<Value, String> {
+    let md = PathBuf::from(model_dir);
+    guard_model_dir(root, &md)?;
+    let mut side = read_sidecar(&md);
+    side.insert("active_profile".into(), json!(profile_id));
+    write_sidecar(&md, &side)?;
+
+    let mut cfg = load_app_config(root);
+    apply_profile_to_cfg(model_dir, &mut cfg);
+    save_app_config(root, &cfg)?;
+
+    // Push hot params if possible (best-effort; UI also does this)
+    Ok(json!({
+        "ok": true,
+        "profiles": list_profiles(root, model_dir)?,
+        "pitch": cfg.get("pitch").cloned().unwrap_or(json!(0)),
+        "formant": cfg.get("formant").cloned().unwrap_or(json!(0.0)),
+        "profile_summary": profile_summary_from_cfg(&cfg),
+        "hot": {
+            "pitch": cfg.get("pitch"),
+            "formant": cfg.get("formant"),
+            "index_rate": cfg.get("index_rate"),
+            "rms_mix_rate": cfg.get("rms_mix_rate"),
+            "threhold": cfg.get("threhold"),
+        }
+    }))
+}
+
+pub fn save_current_as_profile(
+    root: &Path,
+    model_dir: &str,
+    name: &str,
+) -> Result<Value, String> {
+    let md = PathBuf::from(model_dir);
+    guard_model_dir(root, &md)?;
+    let cfg = load_app_config(root);
+    let id = format!(
+        "{:x}",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+            % 0xffff_ffff_ffff
+    );
+    let id = &id[..id.len().min(12)];
+    let mut voice = Map::new();
+    for k in ["pitch", "formant", "index_rate", "rms_mix_rate", "threhold", "f0method"] {
+        if let Some(v) = cfg.get(k) {
+            if !v.is_null() {
+                voice.insert(k.to_string(), v.clone());
+            }
+        }
+    }
+    let mut fx = Map::new();
+    for k in [
+        "fx_enabled",
+        "fx_gate_enabled",
+        "fx_gate_threshold_db",
+        "fx_gate_release_ms",
+        "fx_gate_hold_ms",
+        "fx_gate_range_db",
+        "fx_comp_enabled",
+        "fx_comp_threshold_db",
+        "fx_comp_ratio",
+        "fx_comp_attack_ms",
+        "fx_comp_release_ms",
+        "fx_comp_makeup_db",
+        "fx_eq_enabled",
+        "fx_eq_gains",
+        "fx_eq_preset",
+        "fx_out_gain_db",
+    ] {
+        if let Some(v) = cfg.get(k) {
+            if !v.is_null() {
+                fx.insert(k.to_string(), v.clone());
+            }
+        }
+    }
+    let mut perf = Map::new();
+    for k in ["block_time", "crossfade_length", "extra_time"] {
+        if let Some(v) = cfg.get(k) {
+            if !v.is_null() {
+                perf.insert(k.to_string(), v.clone());
+            }
+        }
+    }
+    let display = if name.trim().is_empty() {
+        "未命名档案"
+    } else {
+        name.trim()
+    };
+    let for_model = md
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("")
+        .to_string();
+    let now = chrono_lite_now();
+    let prof = json!({
+        "schema_version": 1,
+        "id": id,
+        "name": display.chars().take(60).collect::<String>(),
+        "voice": voice,
+        "fx": fx,
+        "perf": perf,
+        "meta": {
+            "source": "self",
+            "score": null,
+            "for_model": for_model,
+            "created": now,
+        }
+    });
+    let dir = profiles_dir(&md);
+    fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    write_json_atomic(&dir.join(format!("{id}{PROFILE_EXT}")), &prof)?;
+    set_active_profile(root, model_dir, id)
+}
+
+fn chrono_lite_now() -> String {
+    // Local-ish YYYY-MM-DD HH:MM:SS without chrono dep
+    use std::time::SystemTime;
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    // UTC approximation is fine for created stamp
+    let days = secs / 86400;
+    let rem = secs % 86400;
+    let h = rem / 3600;
+    let m = (rem % 3600) / 60;
+    let s = rem % 60;
+    // rough civil date from days since epoch
+    let (y, mo, d) = days_to_ymd(days as i64);
+    format!("{y:04}-{mo:02}-{d:02} {h:02}:{m:02}:{s:02}")
+}
+
+fn days_to_ymd(mut days: i64) -> (i32, u32, u32) {
+    // Algorithm from civil_from_days (Howard Hinnant)
+    days += 719468;
+    let era = if days >= 0 { days } else { days - 146096 } / 146097;
+    let doe = (days - era * 146097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = (yoe as i64) + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y as i32, m as u32, d as u32)
+}
+
+pub fn delete_profile(root: &Path, model_dir: &str, profile_id: &str) -> Result<Value, String> {
+    let md = PathBuf::from(model_dir);
+    guard_model_dir(root, &md)?;
+    if profile_id.is_empty() {
+        return Err("不能删除默认档案".into());
+    }
+    let path = profiles_dir(&md).join(format!("{profile_id}{PROFILE_EXT}"));
+    let _ = fs::remove_file(&path);
+    let side = read_sidecar(&md);
+    if side
+        .get("active_profile")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        == profile_id
+    {
+        return set_active_profile(root, model_dir, "");
+    }
+    list_profiles(root, model_dir)
+}
+
+pub fn import_profile(root: &Path, model_dir: &str) -> Result<Value, String> {
+    let path = rfd::FileDialog::new()
+        .add_filter("配置档案", &["tmvp", "json"])
+        .set_title("导入配置档案")
+        .pick_file()
+        .ok_or_else(|| "已取消".to_string())?;
+    let raw = fs::read_to_string(&path).map_err(|e| e.to_string())?;
+    let mut data: Value = serde_json::from_str(&raw).map_err(|e| format!("无效档案: {e}"))?;
+    if !data.is_object() {
+        return Err("档案格式无效".into());
+    }
+    let id = data
+        .get("id")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| {
+            format!(
+                "{:x}",
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map(|d| d.as_nanos())
+                    .unwrap_or(0)
+                    % 0xffff_ffff
+            )
+        });
+    if let Some(obj) = data.as_object_mut() {
+        obj.insert("id".into(), json!(id));
+        if let Some(meta) = obj.get_mut("meta").and_then(|v| v.as_object_mut()) {
+            meta.insert("source".into(), json!("import"));
+        } else {
+            obj.insert(
+                "meta".into(),
+                json!({"source": "import", "score": null, "for_model": "", "created": chrono_lite_now()}),
+            );
+        }
+    }
+    let md = PathBuf::from(model_dir);
+    guard_model_dir(root, &md)?;
+    let dir = profiles_dir(&md);
+    fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    write_json_atomic(&dir.join(format!("{id}{PROFILE_EXT}")), &data)?;
+    set_active_profile(root, model_dir, &id)
+}
+
+pub fn export_active_profile(root: &Path, model_dir: &str) -> Result<Value, String> {
+    let md = PathBuf::from(model_dir);
+    guard_model_dir(root, &md)?;
+    let side = read_sidecar(&md);
+    let pid = side
+        .get("active_profile")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    if pid.is_empty() {
+        return Err("当前是默认参数，没有可导出的档案。请先「另存当前为档案」。".into());
+    }
+    let src = profiles_dir(&md).join(format!("{pid}{PROFILE_EXT}"));
+    if !src.is_file() {
+        return Err("活动档案文件不存在".into());
+    }
+    let name = read_json(&src)
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or(&pid)
+        .to_string();
+    let safe: String = name
+        .chars()
+        .map(|c| {
+            if r#"\/:*?"<>|"#.contains(c) {
+                '_'
+            } else {
+                c
+            }
+        })
+        .take(80)
+        .collect();
+    let dest = rfd::FileDialog::new()
+        .set_file_name(format!("{safe}.tmvp"))
+        .add_filter("配置档案", &["tmvp"])
+        .set_title("导出当前档案（可分享）")
+        .save_file()
+        .ok_or_else(|| "已取消".to_string())?;
+    fs::copy(&src, &dest).map_err(|e| e.to_string())?;
+    Ok(json!({ "ok": true, "path": dest.to_string_lossy() }))
+}
+
+// ---------------------------------------------------------------------------
+// import / delete / open / promote
+// ---------------------------------------------------------------------------
+
+pub fn pick_import_files() -> Vec<String> {
+    rfd::FileDialog::new()
+        .add_filter("音色", &["pth", "index", "zip"])
+        .add_filter("全部", &["*"])
+        .set_title("导入音色…")
+        .pick_files()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect()
+}
+
+pub fn import_files(
+    root: &Path,
+    paths: &[String],
+    current_model_dir: Option<&str>,
+) -> Result<Value, String> {
+    let _ = paths::ensure_user_dirs(root);
+    let models_root = paths::models_dir(root);
+    let mut models = Vec::new();
+    let mut indices = Vec::new();
+    let mut errors = Vec::new();
+    let mut skipped = Vec::new();
+
+    for p in paths {
+        let path = PathBuf::from(p);
+        if !path.is_file() {
+            errors.push(json!({"path": p, "error": "文件不存在"}));
+            continue;
+        }
+        let ext = path
+            .extension()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_ascii_lowercase();
+        match ext.as_str() {
+            "zip" => match crate::store::install_voice_pack_zip(
+                root,
+                &path,
+                "",
+                "",
+                "音色",
+                false, // local user import — never mark as 图灵镜 official
+            ) {
+                Ok(info) => models.push(info),
+                Err(e) => errors.push(json!({"path": p, "error": e})),
+            },
+            "pth" => match import_pth(root, &path) {
+                Ok(info) => models.push(info),
+                Err(e) => errors.push(json!({"path": p, "error": e})),
+            },
+            "index" => {
+                let md = current_model_dir
+                    .filter(|s| !s.is_empty())
+                    .map(PathBuf::from)
+                    .ok_or_else(|| "导入 .index 需要先选中一个可管理音色".to_string());
+                match md {
+                    Ok(md) => match guard_model_dir(root, &md)
+                        .and_then(|_| ensure_index_in_model_dir(&md, &path))
+                    {
+                        Ok(local) => {
+                            let mut side = read_sidecar(&md);
+                            side.insert("index".into(), json!(local));
+                            let mut files: Vec<String> = side
+                                .get("index_files")
+                                .and_then(|v| v.as_array())
+                                .map(|a| {
+                                    a.iter()
+                                        .filter_map(|x| x.as_str().map(|s| s.to_string()))
+                                        .collect()
+                                })
+                                .unwrap_or_default();
+                            if !files.iter().any(|f| f == &local) {
+                                files.push(local.clone());
+                            }
+                            side.insert("index_files".into(), json!(files));
+                            let _ = write_sidecar(&md, &side);
+                            indices.push(json!({"path": local, "model_dir": md.to_string_lossy()}));
+                        }
+                        Err(e) => errors.push(json!({"path": p, "error": e})),
+                    },
+                    Err(e) => errors.push(json!({"path": p, "error": e})),
+                }
+            }
+            _ => skipped.push(p.clone()),
+        }
+    }
+    let _ = models_root;
+    Ok(json!({
+        "models": models,
+        "indices": indices,
+        "errors": errors,
+        "skipped_other": skipped,
+    }))
+}
+
+fn import_pth(root: &Path, src: &Path) -> Result<Value, String> {
+    let name = safe_model_dir_name(
+        src.file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("voice"),
+    )?;
+    let dest_dir = paths::models_dir(root).join(&name);
+    fs::create_dir_all(&dest_dir).map_err(|e| e.to_string())?;
+    let dest_pth = dest_dir.join(src.file_name().unwrap_or_default());
+    if dest_pth.canonicalize().ok() != src.canonicalize().ok() {
+        fs::copy(src, &dest_pth).map_err(|e| format!("复制 .pth 失败: {e}"))?;
+    }
+    // sibling index
+    let mut index_path = String::new();
+    let sib = src.with_extension("index");
+    if sib.is_file() {
+        index_path = ensure_index_in_model_dir(&dest_dir, &sib)?;
+    } else if let Some(parent) = src.parent() {
+        if let Ok(rd) = fs::read_dir(parent) {
+            for e in rd.flatten() {
+                let p = e.path();
+                if p.extension()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("")
+                    .eq_ignore_ascii_case("index")
+                {
+                    let stem = src.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+                    let pname = p.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+                    if pname.contains(stem) || pname.contains(&name) {
+                        index_path = ensure_index_in_model_dir(&dest_dir, &p)?;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    let mut side = Map::new();
+    side.insert("name".into(), json!(name));
+    side.insert("tag".into(), json!(guess_tag(&name)));
+    side.insert(
+        "file".into(),
+        json!(dest_pth.file_name().and_then(|s| s.to_str()).unwrap_or("")),
+    );
+    side.insert("source".into(), json!("import"));
+    if !index_path.is_empty() {
+        side.insert("index".into(), json!(index_path));
+        side.insert("index_files".into(), json!([index_path]));
+    }
+    write_sidecar(&dest_dir, &side)?;
+    Ok(json!({
+        "name": name,
+        "path": dest_pth.to_string_lossy(),
+        "file": dest_pth.file_name().and_then(|s| s.to_str()).unwrap_or(""),
+        "dir": dest_dir.to_string_lossy(),
+        "index": index_path,
+        "tag": guess_tag(&name),
+        "source": "user_data",
+    }))
+}
+
+pub fn delete_voice(root: &Path, model_dir: &str) -> Result<Value, String> {
+    let md = PathBuf::from(model_dir);
+    guard_model_dir(root, &md)?;
+    fn clear_ro(p: &Path) {
+        if let Ok(meta) = fs::metadata(p) {
+            let mut perms = meta.permissions();
+            perms.set_readonly(false);
+            let _ = fs::set_permissions(p, perms);
+        }
+    }
+    fn rm(p: &Path) -> Result<(), String> {
+        if p.is_file() {
+            clear_ro(p);
+            return fs::remove_file(p).map_err(|e| e.to_string());
+        }
+        if p.is_dir() {
+            for e in fs::read_dir(p).map_err(|e| e.to_string())? {
+                rm(&e.map_err(|e| e.to_string())?.path())?;
+            }
+            clear_ro(p);
+            return fs::remove_dir(p).map_err(|e| e.to_string());
+        }
+        Ok(())
+    }
+    rm(&md)?;
+    Ok(json!({"ok": true}))
+}
+
+pub fn rename_voice(root: &Path, model_dir: &str, new_name: &str) -> Result<Value, String> {
+    let md = PathBuf::from(model_dir);
+    guard_model_dir(root, &md)?;
+    let name = new_name.trim();
+    if name.is_empty() {
+        return Err("名称不能为空".into());
+    }
+    let mut side = read_sidecar(&md);
+    side.insert("name".into(), json!(name));
+    write_sidecar(&md, &side)?;
+    Ok(json!({"ok": true, "name": name}))
+}
+
+pub fn promote_legacy(root: &Path, pth_path: &str) -> Result<Value, String> {
+    let src = PathBuf::from(pth_path);
+    if !src.is_file() {
+        return Err("源 .pth 不存在".into());
+    }
+    import_pth(root, &src)
+}
+
+pub fn open_models_dir(root: &Path) -> Result<(), String> {
+    let d = paths::models_dir(root);
+    fs::create_dir_all(&d).map_err(|e| e.to_string())?;
+    #[cfg(windows)]
+    {
+        std::process::Command::new("explorer")
+            .arg(d.as_os_str())
+            .spawn()
+            .map_err(|e| e.to_string())?;
+        return Ok(());
+    }
+    #[cfg(not(windows))]
+    {
+        std::process::Command::new("xdg-open")
+            .arg(d.as_os_str())
+            .spawn()
+            .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+}
+
+pub fn current_selection_summary(root: &Path) -> Value {
+    let cat = list_voices(root);
+    let idx = cat.get("selected_idx").and_then(|v| v.as_i64()).unwrap_or(-1);
+    let models = cat.get("models").and_then(|v| v.as_array());
+    let model = if idx >= 0 {
+        models.and_then(|a| a.get(idx as usize).cloned())
+    } else {
+        None
+    };
+    let cfg = load_app_config(root);
+    let mut profile_name = String::new();
+    if let Some(ref m) = model {
+        if let Some(dir) = m.get("dir").and_then(|v| v.as_str()) {
+            if m.get("source").and_then(|v| v.as_str()) == Some("user_data") {
+                let side = read_sidecar(Path::new(dir));
+                let pid = side
+                    .get("active_profile")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                if !pid.is_empty() {
+                    let prof = read_json(&Path::new(dir).join(PROFILES_DIR).join(format!(
+                        "{pid}{PROFILE_EXT}"
+                    )));
+                    profile_name = prof
+                        .get("name")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                }
+            }
+        }
+    }
+    let mut cfg2 = cfg.clone();
+    cfg2.insert("_active_profile_name".into(), json!(profile_name));
+    json!({
+        "model": model,
+        "pitch": cfg.get("pitch").cloned().unwrap_or(json!(0)),
+        "formant": cfg.get("formant").cloned().unwrap_or(json!(0.0)),
+        "profile_summary": profile_summary_from_cfg(&cfg2),
+        "catalog": cat,
+    })
+}

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -26,7 +26,11 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": null,
+      "assetProtocol": {
+        "enable": true,
+        "scope": ["**"]
+      }
     }
   },
   "bundle": {

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -6,6 +6,7 @@ import { TitleBar } from "./components/TitleBar";
 import { useEngine } from "./hooks/useEngine";
 import { ensureEngine, forceKillEngine, getProvisionStatus } from "./lib/engine";
 import type { PageId } from "./lib/nav";
+import { currentVoice } from "./lib/voices";
 import { HelpPage } from "./pages/HelpPage";
 import { HomePage } from "./pages/HomePage";
 import { ModelsPage } from "./pages/ModelsPage";
@@ -16,10 +17,12 @@ import { SettingsPage } from "./pages/SettingsPage";
 export default function App() {
   const [page, setPage] = useState<PageId>("home");
   const [compactNav, setCompactNav] = useState(false);
-  const [pitch, setPitch] = useState(15);
-  const [formant, setFormant] = useState(1.2);
+  const [pitch, setPitch] = useState(0);
+  const [formant, setFormant] = useState(0);
   const [mode, setMode] = useState<OutputMode>("vc");
-  const [voiceId, setVoiceId] = useState("anon");
+  const [voiceName, setVoiceName] = useState("未选择模型");
+  const [voiceId, setVoiceId] = useState("");
+  const [profileSummary, setProfileSummary] = useState("默认（原始参数）");
   const [showProvision, setShowProvision] = useState(false);
   const [provisionDismissed, setProvisionDismissed] = useState(false);
 
@@ -39,10 +42,21 @@ export default function App() {
     return () => mq.removeEventListener("change", fn);
   }, []);
 
-  const profileSummary =
-    pitch === 0 && formant === 0
-      ? "默认（原始参数）"
-      : `当前 · 音高 ${pitch >= 0 ? "+" : ""}${pitch} 共鸣 ${formant.toFixed(2)}`;
+  useEffect(() => {
+    void currentVoice()
+      .then((c) => {
+        if (c.model) {
+          setVoiceName(String(c.model.name || "未选择模型"));
+          setVoiceId(String(c.model.path || c.model.dir || c.model.name || ""));
+        }
+        if (c.pitch != null) setPitch(Number(c.pitch));
+        if (c.formant != null) setFormant(Number(c.formant));
+        if (c.profile_summary) setProfileSummary(c.profile_summary);
+      })
+      .catch(() => {
+        /* browser preview */
+      });
+  }, []);
 
   const handlePitch = (v: number) => {
     setPitch(v);
@@ -94,13 +108,23 @@ export default function App() {
                 <HomePage
                   currentId={voiceId}
                   onOpenModels={() => setPage("models")}
-                  onSelect={setVoiceId}
+                  onSelect={(id) => setVoiceId(id)}
                 />
               );
             case "plaza":
               return <PlazaPage />;
             case "models":
-              return <ModelsPage />;
+              return (
+                <ModelsPage
+                  onVoiceChange={({ model, pitch: p, formant: f, profileSummary: ps }) => {
+                    setVoiceName(model.name || "未选择模型");
+                    setVoiceId(model.path || model.dir || model.name || "");
+                    if (p != null) setPitch(Number(p));
+                    if (f != null) setFormant(Number(f));
+                    if (ps) setProfileSummary(ps);
+                  }}
+                />
+              );
             case "settings":
               return (
                 <SettingsPage
@@ -130,9 +154,7 @@ export default function App() {
       </PageHost>
 
       <Dock
-        voiceName={
-          voiceId === "anon" ? "Anon" : voiceId === "soyo" ? "Soyo" : "Rana"
-        }
+        voiceName={voiceName}
         pitch={pitch}
         formant={formant}
         onPitch={handlePitch}

--- a/app/src/components/StoreDialog.tsx
+++ b/app/src/components/StoreDialog.tsx
@@ -1,0 +1,364 @@
+import { listen } from "@tauri-apps/api/event";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  cancelStoreDownload,
+  fetchStoreCatalog,
+  installStoreVoice,
+  type StoreCatalog,
+  type StoreVoice,
+} from "../lib/voices";
+import { Btn, Group, ListItem } from "./ui";
+import { SegmentControl } from "./SegmentControl";
+
+type View = "latest" | "official" | "thirdparty" | "series";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onInstalled: () => void;
+};
+
+const PER_PAGE = 8;
+
+export function StoreDialog({ open, onClose, onInstalled }: Props) {
+  const [cat, setCat] = useState<StoreCatalog | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [view, setView] = useState<View>("latest");
+  const [q, setQ] = useState("");
+  const [page, setPage] = useState(1);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [progress, setProgress] = useState("");
+  const [err, setErr] = useState("");
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [thirdAck, setThirdAck] = useState(false);
+
+  const refresh = useCallback(async (remote = true) => {
+    setLoading(true);
+    setErr("");
+    try {
+      const c = await fetchStoreCatalog(remote);
+      setCat(c);
+      if (c.fetch_error) setErr(c.fetch_error);
+    } catch (e) {
+      setErr(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    void refresh(true);
+    setPage(1);
+    setQ("");
+    setView("latest");
+    setThirdAck(false);
+  }, [open, refresh]);
+
+  useEffect(() => {
+    if (!open) return;
+    let un: (() => void) | undefined;
+    void listen<{
+      voice_id?: string;
+      message?: string;
+      percent?: number;
+      phase?: string;
+    }>("store-progress", (ev) => {
+      const p = ev.payload;
+      setProgress(
+        `${p.message || p.phase || "下载中"} ${
+          p.percent != null ? `· ${p.percent}%` : ""
+        }`,
+      );
+    }).then((fn) => {
+      un = fn;
+    });
+    return () => {
+      un?.();
+    };
+  }, [open]);
+
+  const official = cat?.voices || [];
+  const third = cat?.thirdparty_voices || [];
+
+  const list = useMemo(() => {
+    let base: StoreVoice[] = [];
+    if (view === "official") base = official;
+    else if (view === "thirdparty") base = third;
+    else if (view === "series") {
+      base = [...official, ...third].filter((v) => (v.series || "").trim());
+    } else {
+      // latest: merge by date desc
+      base = [...official, ...third].sort((a, b) =>
+        String(b.date || "").localeCompare(String(a.date || "")),
+      );
+    }
+    const qq = q.trim().toLowerCase();
+    if (qq) {
+      base = base.filter((v) =>
+        [v.name, v.tag, v.author, v.series, v.id]
+          .map((x) => String(x || "").toLowerCase())
+          .some((s) => s.includes(qq)),
+      );
+    }
+    return base;
+  }, [view, official, third, q]);
+
+  const seriesGroups = useMemo(() => {
+    if (view !== "series") return null;
+    const map = new Map<string, StoreVoice[]>();
+    for (const v of list) {
+      const s = (v.series || "其他").trim() || "其他";
+      if (!map.has(s)) map.set(s, []);
+      map.get(s)!.push(v);
+    }
+    return [...map.entries()].sort((a, b) => a[0].localeCompare(b[0], "zh"));
+  }, [view, list]);
+
+  const totalPages = Math.max(1, Math.ceil(list.length / PER_PAGE));
+  const pageClamped = Math.min(page, totalPages);
+  const pageItems =
+    view === "series"
+      ? []
+      : list.slice((pageClamped - 1) * PER_PAGE, pageClamped * PER_PAGE);
+
+  const install = async (v: StoreVoice) => {
+    if (v.installed || busyId) return;
+    if (v.official === false && !thirdAck) {
+      const ok = window.confirm(
+        "第三方音色免责声明\n\n" +
+          "该音色来自第三方社区，图灵镜未做安全与质量保证。\n" +
+          "模型文件为 pickle 格式，请只从你信任的来源下载。\n\n" +
+          "继续安装即表示你了解风险。",
+      );
+      if (!ok) return;
+      setThirdAck(true);
+    }
+    setBusyId(v.id);
+    setProgress("排队…");
+    setErr("");
+    try {
+      await installStoreVoice(v);
+      setProgress("安装完成");
+      onInstalled();
+      await refresh(false);
+    } catch (e) {
+      setErr(String(e));
+      setProgress("");
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[80] flex items-center justify-center p-6 bg-[color-mix(in_srgb,var(--ink)_28%,transparent)]"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-[720px] max-h-[min(86vh,760px)] flex flex-col rounded-[var(--r)] bg-[var(--surface)] shadow-[0_20px_60px_rgba(0,0,0,0.22)] overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="px-5 pt-4 pb-3 flex items-start justify-between gap-3">
+          <div>
+            <h3 className="text-[18px] font-semibold m-0">社区音色</h3>
+            <div className="text-[12px] text-[var(--meta)] mt-1">
+              图灵镜源与第三方源 · 双源并发下载（安装逐个进行）
+              {cat?.source ? ` · 清单：${cat.source}` : ""}
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <Btn onClick={() => void refresh(true)} disabled={loading}>
+              {loading ? "刷新中…" : "刷新清单"}
+            </Btn>
+            <Btn onClick={onClose}>关闭</Btn>
+          </div>
+        </div>
+
+        <div className="px-5 pb-3 flex flex-wrap items-center gap-3">
+          <input
+            value={q}
+            onChange={(e) => {
+              setQ(e.target.value);
+              setPage(1);
+            }}
+            placeholder="搜索音色 / 标签 / 作者…"
+            className="min-w-[200px] flex-1 px-[13px] py-[7px] rounded-[var(--rs)] text-[13px] bg-transparent text-[var(--ink)] shadow-[inset_0_0_0_1px_var(--line)] outline-none focus:shadow-[inset_0_0_0_1px_var(--accent)]"
+          />
+          <SegmentControl<View>
+            value={view}
+            onChange={(v) => {
+              setView(v);
+              setPage(1);
+            }}
+            options={[
+              { id: "latest", label: "最新合流" },
+              { id: "official", label: "图灵镜源" },
+              { id: "thirdparty", label: "第三方" },
+              { id: "series", label: "系列专区" },
+            ]}
+          />
+        </div>
+
+        {view === "thirdparty" || view === "latest" ? (
+          <div className="mx-5 mb-2 text-[11.5px] leading-snug text-[var(--meta)] bg-[color-mix(in_srgb,var(--notify)_12%,transparent)] rounded-[var(--rs)] px-3 py-2">
+            第三方音色未经图灵镜审核，请自行判断来源与安全性。模型为
+            pickle，仅从信任渠道安装。
+          </div>
+        ) : null}
+
+        {(err || progress) && (
+          <div className="px-5 pb-2 text-[12px]">
+            {progress ? (
+              <span className="text-[var(--accent)]">{progress}</span>
+            ) : null}
+            {err ? (
+              <span className="text-[color-mix(in_srgb,#c44_90%,var(--ink))] block mt-0.5">
+                {err}
+              </span>
+            ) : null}
+            {busyId ? (
+              <Btn
+                className="mt-1"
+                onClick={() => {
+                  void cancelStoreDownload();
+                  setBusyId(null);
+                  setProgress("已取消");
+                }}
+              >
+                取消下载
+              </Btn>
+            ) : null}
+          </div>
+        )}
+
+        <div className="flex-1 overflow-y-auto px-5 pb-4">
+          {view === "series" && seriesGroups ? (
+            seriesGroups.length === 0 ? (
+              <Empty />
+            ) : (
+              seriesGroups.map(([series, voices]) => {
+                const openS = expanded.has(series);
+                return (
+                  <div key={series} className="mb-3">
+                    <button
+                      type="button"
+                      className="w-full text-left border-0 bg-[var(--group)] rounded-[var(--rs)] px-3 py-2.5 cursor-pointer flex justify-between items-center"
+                      onClick={() => {
+                        setExpanded((prev) => {
+                          const n = new Set(prev);
+                          if (n.has(series)) n.delete(series);
+                          else n.add(series);
+                          return n;
+                        });
+                      }}
+                    >
+                      <span className="font-semibold text-[14px]">{series}</span>
+                      <span className="text-[12px] text-[var(--meta)]">
+                        {voices.length} 个 · {openS ? "收起" : "展开"}
+                      </span>
+                    </button>
+                    {openS ? (
+                      <Group>
+                        {voices.map((v) => (
+                          <VoiceRow
+                            key={v.id}
+                            v={v}
+                            busy={busyId === v.id}
+                            onInstall={() => void install(v)}
+                          />
+                        ))}
+                      </Group>
+                    ) : null}
+                  </div>
+                );
+              })
+            )
+          ) : pageItems.length === 0 ? (
+            <Empty />
+          ) : (
+            <Group>
+              {pageItems.map((v) => (
+                <VoiceRow
+                  key={v.id}
+                  v={v}
+                  busy={busyId === v.id}
+                  onInstall={() => void install(v)}
+                />
+              ))}
+            </Group>
+          )}
+
+          {view !== "series" && totalPages > 1 ? (
+            <div className="flex items-center justify-center gap-3 mt-4 text-[12.5px] text-[var(--meta)]">
+              <Btn
+                disabled={pageClamped <= 1}
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+              >
+                上一页
+              </Btn>
+              <span>
+                第 <b className="text-[var(--ink)]">{pageClamped}</b> /{" "}
+                <b className="text-[var(--ink)]">{totalPages}</b> 页 · 共{" "}
+                <b className="text-[var(--ink)]">{list.length}</b> 个
+              </span>
+              <Btn
+                disabled={pageClamped >= totalPages}
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              >
+                下一页
+              </Btn>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Empty() {
+  return (
+    <div className="text-[13px] text-[var(--meta)] py-10 text-center">
+      暂无音色条目。检查网络后点「刷新清单」。
+    </div>
+  );
+}
+
+function VoiceRow({
+  v,
+  busy,
+  onInstall,
+}: {
+  v: StoreVoice;
+  busy: boolean;
+  onInstall: () => void;
+}) {
+  return (
+    <ListItem
+      meta={v.origin_label || (v.official === false ? "第三方" : "图灵镜")}
+      title={v.name}
+      desc={[
+        v.tag,
+        v.author ? `作者 · ${v.author}` : "",
+        v.size_label,
+        v.series ? `系列 · ${v.series}` : "",
+        v.date,
+      ]
+        .filter(Boolean)
+        .join(" · ")}
+      right={
+        v.installed ? (
+          <Btn on uw disabled>
+            已安装
+          </Btn>
+        ) : (
+          <Btn primary uw disabled={busy} onClick={onInstall}>
+            {busy ? "安装中…" : "下载"}
+          </Btn>
+        )
+      }
+    />
+  );
+}

--- a/app/src/lib/voices.ts
+++ b/app/src/lib/voices.ts
@@ -1,0 +1,287 @@
+import { convertFileSrc, invoke } from "@tauri-apps/api/core";
+
+function isTauri(): boolean {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+export type VoiceModel = {
+  name: string;
+  path: string;
+  file: string;
+  dir: string;
+  cover?: string;
+  index?: string;
+  has_index?: boolean;
+  tag?: string;
+  author?: string;
+  author_url?: string;
+  source?: string;
+  missing?: boolean;
+  pitch?: number;
+  formant?: number;
+  active_profile?: string;
+  [key: string]: unknown;
+};
+
+export type VoicesCatalog = {
+  models: VoiceModel[];
+  selected_idx: number;
+  models_dir?: string;
+  recent_keys?: string[];
+};
+
+export type IndexItem = {
+  path: string;
+  label: string;
+  badge: string;
+  active: boolean;
+};
+
+export type ProfileItem = {
+  id: string;
+  name: string;
+  source: string;
+  source_label: string;
+  score?: number | null;
+  active: boolean;
+  desc?: string;
+};
+
+export type StoreVoice = {
+  id: string;
+  name: string;
+  tag?: string;
+  version?: string;
+  pack_url?: string;
+  pth_url?: string;
+  cover_url?: string;
+  size_bytes?: number;
+  size_label?: string;
+  sha256?: string;
+  description?: string;
+  author?: string;
+  author_url?: string;
+  date?: string;
+  series?: string;
+  origin?: string;
+  origin_label?: string;
+  source_url?: string;
+  official?: boolean;
+  installed?: boolean;
+};
+
+export type StoreCatalog = {
+  source?: string;
+  voices?: StoreVoice[];
+  thirdparty_voices?: StoreVoice[];
+  fetch_error?: string;
+};
+
+export function coverSrc(path?: string): string {
+  if (!path) return "";
+  if (/^https?:\/\//i.test(path)) return path;
+  if (!isTauri()) return "";
+  try {
+    return convertFileSrc(path);
+  } catch {
+    return "";
+  }
+}
+
+export async function listVoices(): Promise<VoicesCatalog> {
+  if (!isTauri()) {
+    return { models: [], selected_idx: -1 };
+  }
+  return invoke<VoicesCatalog>("voices_list");
+}
+
+export async function selectVoice(m: Pick<VoiceModel, "path" | "dir" | "name">) {
+  if (!isTauri()) return { ok: false };
+  return invoke<{
+    ok?: boolean;
+    model?: VoiceModel;
+    pitch?: number;
+    formant?: number;
+    profile_summary?: string;
+  }>("voices_select", {
+    path: m.path || "",
+    dir: m.dir || "",
+    name: m.name || "",
+  });
+}
+
+export async function currentVoice() {
+  if (!isTauri()) {
+    return { model: null, pitch: 0, formant: 0, profile_summary: "默认（原始参数）" };
+  }
+  return invoke<{
+    model?: VoiceModel | null;
+    pitch?: number;
+    formant?: number;
+    profile_summary?: string;
+    catalog?: VoicesCatalog;
+  }>("voices_current");
+}
+
+export async function listIndex(modelDir: string) {
+  if (!isTauri()) return { items: [] as IndexItem[] };
+  return invoke<{ items: IndexItem[]; active?: string }>("voices_index_list", {
+    modelDir,
+  });
+}
+
+export async function useIndex(modelDir: string, indexPath: string) {
+  if (!isTauri()) return { items: [] as IndexItem[] };
+  return invoke<{ items: IndexItem[] }>("voices_index_use", {
+    modelDir,
+    indexPath,
+  });
+}
+
+export async function bindIndex(modelDir: string) {
+  if (!isTauri()) return { items: [] as IndexItem[] };
+  return invoke<{ items: IndexItem[] }>("voices_index_bind", {
+    modelDir,
+    indexSrc: null,
+  });
+}
+
+export async function unbindIndex(modelDir: string, indexPath: string) {
+  if (!isTauri()) return { items: [] as IndexItem[] };
+  return invoke<{ items: IndexItem[] }>("voices_index_unbind", {
+    modelDir,
+    indexPath,
+  });
+}
+
+export async function listProfiles(modelDir: string) {
+  if (!isTauri()) return { items: [] as ProfileItem[] };
+  return invoke<{ items: ProfileItem[]; active_id?: string }>(
+    "voices_profiles_list",
+    { modelDir },
+  );
+}
+
+export async function useProfile(modelDir: string, profileId: string) {
+  if (!isTauri()) return {};
+  return invoke<{
+    pitch?: number;
+    formant?: number;
+    profile_summary?: string;
+    profiles?: { items: ProfileItem[] };
+    hot?: Record<string, number | undefined>;
+  }>("voices_profile_use", { modelDir, profileId });
+}
+
+export async function saveProfile(modelDir: string, name: string) {
+  if (!isTauri()) return {};
+  return invoke("voices_profile_save", { modelDir, name });
+}
+
+export async function deleteProfile(modelDir: string, profileId: string) {
+  if (!isTauri()) return {};
+  return invoke("voices_profile_delete", { modelDir, profileId });
+}
+
+export async function importProfile(modelDir: string) {
+  if (!isTauri()) return {};
+  return invoke("voices_profile_import", { modelDir });
+}
+
+export async function exportProfile(modelDir: string) {
+  if (!isTauri()) return {};
+  return invoke("voices_profile_export", { modelDir });
+}
+
+export async function importVoices(currentModelDir?: string) {
+  if (!isTauri()) return { models: [], errors: [] };
+  return invoke<{
+    models?: unknown[];
+    indices?: unknown[];
+    errors?: { path: string; error: string }[];
+  }>("voices_import", {
+    paths: null,
+    currentModelDir: currentModelDir || null,
+  });
+}
+
+export async function deleteVoice(modelDir: string) {
+  if (!isTauri()) return;
+  return invoke("voices_delete", { modelDir });
+}
+
+export async function renameVoice(modelDir: string, newName: string) {
+  if (!isTauri()) return;
+  return invoke("voices_rename", { modelDir, newName });
+}
+
+export async function promoteLegacy(pthPath: string) {
+  if (!isTauri()) return;
+  return invoke("voices_promote", { pthPath });
+}
+
+export async function openModelsDir() {
+  if (!isTauri()) return;
+  return invoke("voices_open_dir");
+}
+
+export async function fetchStoreCatalog(preferRemote = true) {
+  if (!isTauri()) {
+    return {
+      source: "demo",
+      voices: [],
+      thirdparty_voices: [],
+      fetch_error: "浏览器预览无法拉清单",
+    } satisfies StoreCatalog;
+  }
+  return invoke<StoreCatalog>("store_catalog", { preferRemote });
+}
+
+export async function installStoreVoice(entry: StoreVoice) {
+  if (!isTauri()) return { ok: false };
+  return invoke("store_install", { entry });
+}
+
+export async function cancelStoreDownload() {
+  if (!isTauri()) return;
+  return invoke("store_cancel");
+}
+
+export function filterSortModels(
+  models: VoiceModel[],
+  query: string,
+  sort: "default" | "name" | "index",
+): VoiceModel[] {
+  const q = query.trim().toLowerCase();
+  let out = q
+    ? models.filter((m) =>
+        [m.name, m.tag, m.file, m.author]
+          .map((x) => String(x || "").toLowerCase())
+          .some((s) => s.includes(q)),
+      )
+    : [...models];
+  if (sort === "name") {
+    out.sort((a, b) =>
+      String(a.name || "").localeCompare(String(b.name || ""), "zh"),
+    );
+  } else if (sort === "index") {
+    out.sort((a, b) => {
+      const ai = a.has_index || a.index ? 0 : 1;
+      const bi = b.has_index || b.index ? 0 : 1;
+      if (ai !== bi) return ai - bi;
+      return String(a.name || "").localeCompare(String(b.name || ""), "zh");
+    });
+  }
+  return out;
+}
+
+export function modelKey(m: VoiceModel): string {
+  if (m.path) return m.path;
+  return `${m.dir || ""}|${m.name || ""}`;
+}
+
+export function colsForWidth(w: number): number {
+  // card_min ≈ 180 + gap; max 5
+  const usable = Math.max(w - 48, 320);
+  return Math.max(1, Math.min(5, Math.floor(usable / 200)));
+}

--- a/app/src/pages/ModelsPage.tsx
+++ b/app/src/pages/ModelsPage.tsx
@@ -1,149 +1,749 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { StoreDialog } from "../components/StoreDialog";
+import { SegmentControl } from "../components/SegmentControl";
 import { Block, Btn, Group, ListItem, PageHead, PagePad } from "../components/ui";
+import { setHot } from "../lib/engine";
+import {
+  bindIndex,
+  colsForWidth,
+  coverSrc,
+  deleteProfile,
+  deleteVoice,
+  exportProfile,
+  filterSortModels,
+  importProfile,
+  importVoices,
+  listIndex,
+  listProfiles,
+  listVoices,
+  modelKey,
+  openModelsDir,
+  promoteLegacy,
+  renameVoice,
+  saveProfile,
+  selectVoice,
+  unbindIndex,
+  useIndex,
+  useProfile,
+  type IndexItem,
+  type ProfileItem,
+  type VoiceModel,
+} from "../lib/voices";
 
-const DEMO = [
-  { id: "anon", name: "Anon", tag: "少女音", author: "望月星逸", index: true, cur: true },
-  { id: "rana", name: "Rana", tag: "少女音", author: "望月星逸", index: true, cur: false },
-  { id: "soyo", name: "Soyo", tag: "少女音", author: "望月星逸", index: true, cur: false },
-  { id: "kiki", name: "Kikiv2", tag: "少女音", author: "RVC", index: false, cur: false },
-  { id: "teio", name: "TokaiTeio", tag: "少女音", author: "RVC", index: false, cur: false },
-];
+export type ModelsPageProps = {
+  onVoiceChange?: (info: {
+    model: VoiceModel;
+    pitch?: number;
+    formant?: number;
+    profileSummary?: string;
+  }) => void;
+};
 
-/** Models page shell — grid, index panel, profiles (demo data until catalog binds). */
-export function ModelsPage() {
+type SortKey = "default" | "name" | "index";
+
+export function ModelsPage({ onVoiceChange }: ModelsPageProps) {
+  const [models, setModels] = useState<VoiceModel[]>([]);
+  const [selectedKey, setSelectedKey] = useState("");
+  const [query, setQuery] = useState("");
+  const [sort, setSort] = useState<SortKey>("default");
+  const [page, setPage] = useState(0);
+  const [cols, setCols] = useState(5);
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState("");
+  const [storeOpen, setStoreOpen] = useState(false);
+  const [indexItems, setIndexItems] = useState<IndexItem[]>([]);
+  const [profiles, setProfiles] = useState<ProfileItem[]>([]);
+  const [menu, setMenu] = useState<{
+    x: number;
+    y: number;
+    model: VoiceModel;
+  } | null>(null);
+  const gridRef = useRef<HTMLDivElement>(null);
+
+  const selected = useMemo(
+    () => models.find((m) => modelKey(m) === selectedKey) || null,
+    [models, selectedKey],
+  );
+
+  const view = useMemo(
+    () => filterSortModels(models, query, sort),
+    [models, query, sort],
+  );
+
+  const pageSize = cols * 3;
+  const totalPages = Math.max(1, Math.ceil(view.length / pageSize) || 1);
+  const pageClamped = Math.min(page, totalPages - 1);
+  const pageView = view.slice(
+    pageClamped * pageSize,
+    pageClamped * pageSize + pageSize,
+  );
+
+  const statusSub = useMemo(() => {
+    if (!models.length) return "共 0 个音色";
+    if (query.trim() && view.length !== models.length) {
+      return `共 ${models.length} 个 · 匹配 ${view.length} 个`;
+    }
+    const cur = selected?.name || models[0]?.name || "—";
+    return `共 ${models.length} 个 · 使用中：${cur}`;
+  }, [models, query, view.length, selected]);
+
+  const reload = useCallback(async () => {
+    try {
+      const cat = await listVoices();
+      setModels(cat.models || []);
+      const idx = cat.selected_idx ?? -1;
+      if (idx >= 0 && cat.models?.[idx]) {
+        setSelectedKey(modelKey(cat.models[idx]));
+      } else if (cat.models?.[0]) {
+        setSelectedKey(modelKey(cat.models[0]));
+      } else {
+        setSelectedKey("");
+      }
+    } catch (e) {
+      setMsg(String(e));
+    }
+  }, []);
+
+  const reloadPanels = useCallback(async (m: VoiceModel | null) => {
+    if (!m || m.source !== "user_data" || !m.dir || m.missing) {
+      setIndexItems([]);
+      setProfiles([]);
+      return;
+    }
+    try {
+      const [ix, pr] = await Promise.all([
+        listIndex(m.dir),
+        listProfiles(m.dir),
+      ]);
+      setIndexItems(ix.items || []);
+      setProfiles(pr.items || []);
+    } catch {
+      setIndexItems([]);
+      setProfiles([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  useEffect(() => {
+    void reloadPanels(selected);
+  }, [selected, reloadPanels]);
+
+  useEffect(() => {
+    const el = gridRef.current?.parentElement || gridRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width || window.innerWidth;
+      setCols(colsForWidth(w));
+    });
+    ro.observe(el);
+    setCols(colsForWidth(el.clientWidth || window.innerWidth));
+    return () => ro.disconnect();
+  }, []);
+
+  useEffect(() => {
+    setPage(0);
+  }, [query, sort]);
+
+  useEffect(() => {
+    if (page > totalPages - 1) setPage(Math.max(0, totalPages - 1));
+  }, [page, totalPages]);
+
+  useEffect(() => {
+    const close = () => setMenu(null);
+    window.addEventListener("click", close);
+    return () => window.removeEventListener("click", close);
+  }, []);
+
+  const onUse = async (m: VoiceModel) => {
+    if (m.missing) {
+      setMsg("这个音色的模型文件缺失或没下载完整");
+      return;
+    }
+    setBusy(true);
+    setMsg("");
+    try {
+      const res = await selectVoice(m);
+      setSelectedKey(modelKey(m));
+      if (res.pitch != null || res.formant != null) {
+        try {
+          await setHot({
+            pitch: Number(res.pitch ?? 0),
+            formant: Number(res.formant ?? 0),
+          });
+        } catch {
+          /* worker may be idle */
+        }
+      }
+      onVoiceChange?.({
+        model: (res.model as VoiceModel) || m,
+        pitch: res.pitch as number | undefined,
+        formant: res.formant as number | undefined,
+        profileSummary: res.profile_summary,
+      });
+      await reload();
+    } catch (e) {
+      setMsg(String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const manageable =
+    selected &&
+    selected.source === "user_data" &&
+    !!selected.dir &&
+    !selected.missing;
+  const promotable =
+    selected &&
+    selected.source === "legacy_weights" &&
+    !!selected.path &&
+    !selected.missing;
+  const blockReason = !selected
+    ? "还没有选择音色。"
+    : selected.missing
+      ? "这个音色的模型文件缺失或没下载完整，先修好或删除后再绑定。"
+      : promotable
+        ? "这是旧版散装音色，先「转为可管理音色」就能绑定检索库和配置档案。"
+        : !manageable
+          ? "这个音色不支持绑定。"
+          : "";
+
   return (
     <PagePad>
       <PageHead
         title="音色目录"
-        sub="共 3 个 · 使用中：Anon"
+        sub={statusSub}
         actions={
           <>
-            <Btn primary>社区音色</Btn>
-            <Btn>导入音色…</Btn>
-            <Btn>刷新</Btn>
-            <Btn>打开目录</Btn>
+            <Btn primary onClick={() => setStoreOpen(true)}>
+              社区音色
+            </Btn>
+            <Btn
+              disabled={busy}
+              onClick={async () => {
+                setBusy(true);
+                try {
+                  const r = await importVoices(selected?.dir);
+                  if (r.errors?.length) {
+                    setMsg(r.errors.map((e) => e.error).join("；"));
+                  }
+                  await reload();
+                } catch (e) {
+                  if (String(e) !== "已取消") setMsg(String(e));
+                } finally {
+                  setBusy(false);
+                }
+              }}
+            >
+              导入音色…
+            </Btn>
+            <Btn
+              onClick={async () => {
+                await reload();
+                setMsg("已刷新");
+              }}
+            >
+              刷新
+            </Btn>
+            <Btn
+              onClick={() => {
+                void openModelsDir().catch((e) => setMsg(String(e)));
+              }}
+            >
+              打开目录
+            </Btn>
           </>
         }
       />
 
+      {msg ? (
+        <div className="text-[12.5px] text-[var(--meta)] mt-2">{msg}</div>
+      ) : null}
+
       <Block>
         <div className="flex items-center gap-3 flex-wrap mb-[18px]">
-          <span className="inline-flex justify-between gap-3 items-center min-w-[230px] px-[13px] py-[7px] rounded-[var(--rs)] text-[13px] text-[var(--meta)] shadow-[inset_0_0_0_1px_var(--line)]">
-            搜索音色 / 标签…
-          </span>
-          <span className="ml-auto flex gap-1.5">
-            <Btn on>默认</Btn>
-            <Btn>名称</Btn>
-            <Btn>检索库</Btn>
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="搜索音色 / 标签…"
+            className="inline-flex min-w-[230px] px-[13px] py-[7px] rounded-[var(--rs)] text-[13px] text-[var(--ink)] bg-transparent shadow-[inset_0_0_0_1px_var(--line)] outline-none focus:shadow-[inset_0_0_0_1px_var(--accent)]"
+          />
+          <span className="ml-auto">
+            <SegmentControl<SortKey>
+              value={sort}
+              onChange={setSort}
+              options={[
+                { id: "default", label: "默认" },
+                { id: "name", label: "名称" },
+                { id: "index", label: "检索库" },
+              ]}
+            />
           </span>
         </div>
 
-        <div className="grid grid-cols-5 gap-x-4 gap-y-[22px] max-[1180px]:grid-cols-4 max-[1020px]:grid-cols-3 max-[720px]:grid-cols-2">
-          {DEMO.map((v) => (
-            <div key={v.id}>
-              <div className="aspect-[4/3] rounded-[var(--r)] grid place-items-center relative bg-[color-mix(in_srgb,var(--ink)_7%,transparent)] text-[color-mix(in_srgb,var(--ink)_32%,transparent)] text-2xl grayscale hover:grayscale-[0.3] transition-[filter,transform] duration-300 ease-[var(--spring)] hover:-translate-y-1">
-                {v.name.slice(0, 4)}
-                {v.cur ? (
-                  <span className="absolute top-2.5 right-2.5 text-[11px] text-[var(--accent)]">
-                    使用中
-                  </span>
-                ) : null}
-                {v.index ? (
-                  <span className="absolute right-2.5 bottom-2 text-[11px] text-[var(--meta)]">
-                    ✓ 检索库
-                  </span>
-                ) : null}
-              </div>
-              <div className="text-[11.5px] text-[var(--meta)] mt-2.5">{v.tag}</div>
-              <div className="text-[14.5px] font-semibold mt-0.5">{v.name}</div>
-              <div className="text-xs text-[var(--meta)] mt-0.5">作者 · {v.author}</div>
-              <div className="mt-2.5">
-                {v.cur ? (
-                  <Btn on uw disabled>
-                    使用中
-                  </Btn>
-                ) : (
-                  <Btn uw>使用</Btn>
-                )}
-              </div>
+        <div
+          ref={gridRef}
+          className="grid gap-x-4 gap-y-[22px]"
+          style={{
+            gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
+          }}
+        >
+          {!models.length ? (
+            <div className="col-span-full text-[13.5px] text-[var(--ink-muted)] py-10 px-2">
+              还没有音色。点「社区音色」在线获取，或点「导入音色」添加 .pth /
+              .index / .zip 包。
             </div>
-          ))}
+          ) : !view.length ? (
+            <div className="col-span-full text-[13.5px] text-[var(--ink-muted)] py-10 px-2">
+              没有匹配「{query}」的音色。清空搜索可看全部。
+            </div>
+          ) : (
+            pageView.map((v) => {
+              const cur = modelKey(v) === selectedKey;
+              const src = coverSrc(v.cover);
+              return (
+                <div
+                  key={modelKey(v)}
+                  onContextMenu={(e) => {
+                    e.preventDefault();
+                    setMenu({ x: e.clientX, y: e.clientY, model: v });
+                  }}
+                >
+                  <div className="aspect-[4/3] rounded-[var(--r)] grid place-items-center relative overflow-hidden bg-[color-mix(in_srgb,var(--ink)_7%,transparent)] text-[color-mix(in_srgb,var(--ink)_32%,transparent)] text-2xl grayscale hover:grayscale-[0.3] transition-[filter,transform] duration-300 ease-[var(--spring)] hover:-translate-y-1">
+                    {src ? (
+                      <img
+                        src={src}
+                        alt=""
+                        className="absolute inset-0 w-full h-full object-cover"
+                        draggable={false}
+                      />
+                    ) : (
+                      <span>{(v.name || "?").slice(0, 4)}</span>
+                    )}
+                    {cur ? (
+                      <span className="absolute top-2.5 right-2.5 text-[11px] text-[var(--accent)] font-semibold drop-shadow">
+                        使用中
+                      </span>
+                    ) : null}
+                    {v.has_index || v.index ? (
+                      <span className="absolute right-2.5 bottom-2 text-[11px] text-[var(--meta)]">
+                        ✓ 检索库
+                      </span>
+                    ) : null}
+                    {v.missing ? (
+                      <span className="absolute left-2.5 top-2.5 text-[11px] text-[#c44]">
+                        缺失
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="text-[11.5px] text-[var(--meta)] mt-2.5">
+                    {v.tag || "音色"}
+                  </div>
+                  <div className="text-[14.5px] font-semibold mt-0.5 truncate">
+                    {v.name}
+                  </div>
+                  <div className="text-xs text-[var(--meta)] mt-0.5 truncate">
+                    {v.author ? `作者 · ${v.author}` : "作者 · —"}
+                  </div>
+                  <div className="mt-2.5">
+                    {cur ? (
+                      <Btn on uw disabled>
+                        使用中
+                      </Btn>
+                    ) : (
+                      <Btn uw disabled={busy || !!v.missing} onClick={() => void onUse(v)}>
+                        使用
+                      </Btn>
+                    )}
+                  </div>
+                </div>
+              );
+            })
+          )}
         </div>
 
-        <div className="flex items-center justify-center gap-3 mt-[26px] text-[12.5px] text-[var(--meta)]">
-          <Btn>上一页</Btn>
-          <span>
-            第 <b className="text-[var(--ink)] font-semibold">1</b> /{" "}
-            <b className="text-[var(--ink)] font-semibold">1</b> 页 · 共{" "}
-            <b className="text-[var(--ink)] font-semibold">3</b> 个
-          </span>
-          <Btn>下一页</Btn>
-        </div>
+        {view.length > pageSize ? (
+          <div className="flex items-center justify-center gap-3 mt-[26px] text-[12.5px] text-[var(--meta)]">
+            <Btn
+              disabled={pageClamped <= 0}
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+            >
+              上一页
+            </Btn>
+            <span>
+              第{" "}
+              <b className="text-[var(--ink)] font-semibold">
+                {pageClamped + 1}
+              </b>{" "}
+              /{" "}
+              <b className="text-[var(--ink)] font-semibold">{totalPages}</b>{" "}
+              页 · 共{" "}
+              <b className="text-[var(--ink)] font-semibold">{view.length}</b>{" "}
+              个
+            </span>
+            <Btn
+              disabled={pageClamped >= totalPages - 1}
+              onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+            >
+              下一页
+            </Btn>
+          </div>
+        ) : null}
       </Block>
 
       <Block
         title="特征索引文件（.index）"
-        note="检索库可选；无 index 也能用"
-        action={<Btn>绑定 index 文件…</Btn>}
+        note={manageable ? "检索库可选；无 index 也能用" : undefined}
+        action={
+          manageable ? (
+            <Btn
+              onClick={async () => {
+                try {
+                  const r = await bindIndex(selected!.dir);
+                  setIndexItems(r.items || []);
+                  await reload();
+                } catch (e) {
+                  if (String(e) !== "已取消") setMsg(String(e));
+                }
+              }}
+            >
+              绑定 index 文件…
+            </Btn>
+          ) : undefined
+        }
       >
-        <Group>
-          <ListItem title="不用检索库（仅 .pth）" right={<Btn uw>使用</Btn>} />
-          <ListItem
-            title="added_IVF256_Flat_nprobe_1_Anon-local_v2.index"
-            desc="当前音色目录"
-            right={
-              <Btn on uw disabled>
-                使用中
-              </Btn>
-            }
-          />
-        </Group>
+        {!manageable ? (
+          <div className="text-[13px] text-[var(--meta)]">
+            {blockReason}
+            {promotable ? (
+              <div className="mt-2">
+                <Btn
+                  onClick={async () => {
+                    try {
+                      await promoteLegacy(selected!.path);
+                      await reload();
+                      setMsg("已转为可管理音色");
+                    } catch (e) {
+                      setMsg(String(e));
+                    }
+                  }}
+                >
+                  转为可管理音色
+                </Btn>
+              </div>
+            ) : null}
+          </div>
+        ) : (
+          <Group>
+            {indexItems.map((it) => (
+              <ListItem
+                key={it.path || "__none__"}
+                title={it.label}
+                desc={it.badge || undefined}
+                right={
+                  <>
+                    {it.active ? (
+                      <Btn on uw disabled>
+                        使用中
+                      </Btn>
+                    ) : (
+                      <Btn
+                        uw
+                        onClick={async () => {
+                          const r = await useIndex(selected!.dir, it.path);
+                          setIndexItems(r.items || []);
+                          await reload();
+                        }}
+                      >
+                        使用
+                      </Btn>
+                    )}
+                    {it.path && !it.active ? (
+                      <Btn
+                        onClick={async () => {
+                          const r = await unbindIndex(selected!.dir, it.path);
+                          setIndexItems(r.items || []);
+                          await reload();
+                        }}
+                      >
+                        解绑
+                      </Btn>
+                    ) : null}
+                  </>
+                }
+              />
+            ))}
+          </Group>
+        )}
       </Block>
 
       <Block
         title="配置档案"
         note="同一个音色可存多套参数（音高／音效／性能），点「使用」即切换；可导出分享，也能导入别人调好的档案"
       >
-        <Group>
-          <ListItem
-            meta="原始"
-            title="默认（原始参数）"
-            right={<Btn uw>使用</Btn>}
-          />
-          <ListItem
-            meta="自建"
-            title="开黑日常"
-            desc="音高 +15 · 共鸣 1.20 · 相似度 0.86"
-            right={
-              <>
-                <Btn on uw disabled>
-                  使用中
-                </Btn>
-                <Btn>删除</Btn>
-              </>
-            }
-          />
-          <ListItem
-            meta="官方优化"
-            title="唱歌"
-            desc="音高 +12 · 共鸣 0.80 · 相似度 0.91"
-            right={
-              <>
-                <Btn uw>使用</Btn>
-                <Btn>删除</Btn>
-              </>
-            }
-          />
-          <ListItem
-            right={
-              <>
-                <Btn>另存当前为档案</Btn>
-                <Btn>导入档案…</Btn>
-                <Btn>导出当前档案（可分享）…</Btn>
-              </>
-            }
-          />
-        </Group>
+        {!manageable ? (
+          <div className="text-[13px] text-[var(--meta)]">{blockReason}</div>
+        ) : (
+          <>
+            <Group>
+              {profiles.map((p) => (
+                <ListItem
+                  key={p.id || "__default__"}
+                  meta={p.source_label}
+                  title={p.name}
+                  desc={p.desc || undefined}
+                  right={
+                    <>
+                      {p.active ? (
+                        <Btn on uw disabled>
+                          使用中
+                        </Btn>
+                      ) : (
+                        <Btn
+                          uw
+                          onClick={async () => {
+                            const r = await useProfile(selected!.dir, p.id);
+                            if (r.profiles?.items) setProfiles(r.profiles.items);
+                            else {
+                              const pr = await listProfiles(selected!.dir);
+                              setProfiles(pr.items || []);
+                            }
+                            if (r.hot) {
+                              try {
+                                await setHot({
+                                  pitch:
+                                    r.hot.pitch != null
+                                      ? Number(r.hot.pitch)
+                                      : undefined,
+                                  formant:
+                                    r.hot.formant != null
+                                      ? Number(r.hot.formant)
+                                      : undefined,
+                                  index_rate:
+                                    r.hot.index_rate != null
+                                      ? Number(r.hot.index_rate)
+                                      : undefined,
+                                  rms_mix_rate:
+                                    r.hot.rms_mix_rate != null
+                                      ? Number(r.hot.rms_mix_rate)
+                                      : undefined,
+                                  threhold:
+                                    r.hot.threhold != null
+                                      ? Number(r.hot.threhold)
+                                      : undefined,
+                                });
+                              } catch {
+                                /* */
+                              }
+                            }
+                            if (selected) {
+                              onVoiceChange?.({
+                                model: selected,
+                                pitch: r.pitch as number | undefined,
+                                formant: r.formant as number | undefined,
+                                profileSummary: r.profile_summary,
+                              });
+                            }
+                          }}
+                        >
+                          使用
+                        </Btn>
+                      )}
+                      {p.id ? (
+                        <Btn
+                          onClick={async () => {
+                            if (
+                              !window.confirm(
+                                `删除档案「${p.name}」？此操作无法撤销。`,
+                              )
+                            )
+                              return;
+                            await deleteProfile(selected!.dir, p.id);
+                            const pr = await listProfiles(selected!.dir);
+                            setProfiles(pr.items || []);
+                          }}
+                        >
+                          删除
+                        </Btn>
+                      ) : null}
+                    </>
+                  }
+                />
+              ))}
+              <ListItem
+                right={
+                  <>
+                    <Btn
+                      onClick={async () => {
+                        const name = window.prompt("档案名称", "我的档案");
+                        if (name == null) return;
+                        await saveProfile(selected!.dir, name);
+                        const pr = await listProfiles(selected!.dir);
+                        setProfiles(pr.items || []);
+                      }}
+                    >
+                      另存当前为档案
+                    </Btn>
+                    <Btn
+                      onClick={async () => {
+                        try {
+                          await importProfile(selected!.dir);
+                          const pr = await listProfiles(selected!.dir);
+                          setProfiles(pr.items || []);
+                        } catch (e) {
+                          if (String(e) !== "已取消") setMsg(String(e));
+                        }
+                      }}
+                    >
+                      导入档案…
+                    </Btn>
+                    <Btn
+                      onClick={async () => {
+                        try {
+                          await exportProfile(selected!.dir);
+                          setMsg("档案已导出");
+                        } catch (e) {
+                          if (String(e) !== "已取消") setMsg(String(e));
+                        }
+                      }}
+                    >
+                      导出当前档案（可分享）…
+                    </Btn>
+                  </>
+                }
+              />
+            </Group>
+          </>
+        )}
       </Block>
+
+      {menu ? (
+        <ContextMenu
+          x={menu.x}
+          y={menu.y}
+          model={menu.model}
+          onClose={() => setMenu(null)}
+          onDone={async () => {
+            setMenu(null);
+            await reload();
+          }}
+          onMessage={setMsg}
+        />
+      ) : null}
+
+      <StoreDialog
+        open={storeOpen}
+        onClose={() => setStoreOpen(false)}
+        onInstalled={() => {
+          void reload();
+        }}
+      />
     </PagePad>
+  );
+}
+
+function ContextMenu({
+  x,
+  y,
+  model,
+  onClose,
+  onDone,
+  onMessage,
+}: {
+  x: number;
+  y: number;
+  model: VoiceModel;
+  onClose: () => void;
+  onDone: () => void;
+  onMessage: (s: string) => void;
+}) {
+  const items: { label: string; action: () => void; danger?: boolean }[] = [];
+  if (model.source === "user_data" && model.dir) {
+    items.push({
+      label: "重命名",
+      action: async () => {
+        const n = window.prompt("新名称", model.name);
+        if (!n) return;
+        try {
+          await renameVoice(model.dir, n);
+          onDone();
+        } catch (e) {
+          onMessage(String(e));
+        }
+      },
+    });
+    items.push({
+      label: "删除",
+      danger: true,
+      action: async () => {
+        if (
+          !window.confirm(
+            "模型文件、绑定的配置档案会一起删除，无法撤销。\n\n确认删除？",
+          )
+        )
+          return;
+        try {
+          await deleteVoice(model.dir);
+          onDone();
+        } catch (e) {
+          onMessage(String(e));
+        }
+      },
+    });
+  }
+  if (model.author_url) {
+    items.push({
+      label: "打开作者链接",
+      action: () => {
+        window.open(model.author_url, "_blank", "noopener,noreferrer");
+        onClose();
+      },
+    });
+  }
+  if (model.source === "legacy_weights" && model.path) {
+    items.push({
+      label: "转为可管理音色",
+      action: async () => {
+        try {
+          await promoteLegacy(model.path);
+          onDone();
+        } catch (e) {
+          onMessage(String(e));
+        }
+      },
+    });
+  }
+  if (!items.length) {
+    items.push({
+      label: "无可用操作",
+      action: onClose,
+    });
+  }
+
+  return (
+    <div
+      className="fixed z-[90] min-w-[160px] py-1 rounded-[var(--rs)] bg-[var(--surface)] shadow-[0_8px_28px_rgba(0,0,0,0.18)]"
+      style={{ left: x, top: y }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {items.map((it) => (
+        <button
+          key={it.label}
+          type="button"
+          className={[
+            "block w-full text-left border-0 bg-transparent px-3.5 py-2 text-[13px] cursor-pointer",
+            it.danger
+              ? "text-[#c44] hover:bg-[color-mix(in_srgb,#c44_10%,transparent)]"
+              : "text-[var(--ink)] hover:bg-[color-mix(in_srgb,var(--ink)_5%,transparent)]",
+          ].join(" ")}
+          onClick={() => void it.action()}
+        >
+          {it.label}
+        </button>
+      ))}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Local voice catalog: User_Data models + legacy weights, 5×3 grid, search/sort
- Index panel: bind / use / unbind `.index` (copied next to `.pth`)
- Config profiles: list / switch / save / import / export `.tmvp`
- Import/delete/rename/promote legacy; dock wired to selection
- Community store dialog: dual source, series zone, third-party disclaimer, multi-connection VoicePack downloads via ripget

## Test plan
- [ ] `npm run build` in `app/`
- [ ] `cargo check` in `app/src-tauri` (MSVC env)
- [ ] Models page lists local voices; use/switch works
- [ ] Index + profiles panels for manageable voices
- [ ] Community store refresh + install (optional network)